### PR TITLE
Special

### DIFF
--- a/components/Publication/PublishForm.js
+++ b/components/Publication/PublishForm.js
@@ -188,6 +188,7 @@ class PublishForm extends Component {
           const scale = width
             ? Math.min(1, width / (size.width + PADDING_X * 2))
             : 1
+          const roundedScale = Math.round(scale * 10) / 10
 
           return (
             <div>
@@ -324,7 +325,7 @@ class PublishForm extends Component {
                     if (previewSize === size) {
                       return [
                         label,
-                        scale !== 1 && ` (${Math.round(scale * 10) / 10}x)`
+                        roundedScale !== 1 && ` (${roundedScale}x)`
                       ].filter(Boolean).join(' ')
                     }
                     return (

--- a/components/Publication/PublishForm.js
+++ b/components/Publication/PublishForm.js
@@ -119,7 +119,7 @@ class PublishForm extends Component {
       size: PREVIEW_SIZES[0]
     }
   }
-  componentDidMount () {
+  transferCSS () {
     this.setState({
       css: styleSheet.rules().map(r => r.cssText).join('')
     })
@@ -301,6 +301,7 @@ class PublishForm extends Component {
             <Frame
               frameBorder='0'
               allowTransparency='true'
+              contentDidMount={() => this.transferCSS()}
               head={[
                 <style key='glamor'>{css}</style>
               ]}

--- a/components/Publication/PublishForm.js
+++ b/components/Publication/PublishForm.js
@@ -94,9 +94,25 @@ mutation publish(
 }
 `
 
+const PADDING_X = 5
+
 const PREVIEW_SIZES = [
-  {label: 'Mobile', width: 320, height: 480},
-  {label: 'Desktop', width: '100%', height: 600}
+  {
+    label: 'mobile',
+    width: 320,
+    height: 480,
+    paddingTop: 40,
+    paddingBottom: 40,
+    borderRadius: 10
+  },
+  {
+    label: 'desktop',
+    width: 1024,
+    height: 800,
+    paddingTop: PADDING_X,
+    paddingBottom: PADDING_X,
+    borderRadius: 3
+  }
 ]
 
 class PublishForm extends Component {
@@ -118,6 +134,22 @@ class PublishForm extends Component {
       css: '',
       size: PREVIEW_SIZES[0]
     }
+    this.containerRef = ref => { this.container = ref }
+
+    this.measure = () => {
+      this.setState(() => ({
+        width:
+          this.container &&
+          this.container.getBoundingClientRect().width
+      }))
+    }
+  }
+  componentDidMount () {
+    window.addEventListener('resize', this.measure)
+    this.measure()
+  }
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.measure)
   }
   transferCSS () {
     this.setState({
@@ -136,186 +168,213 @@ class PublishForm extends Component {
     const scheduledAtError = scheduledAtDate === null && t('publish/label/scheduledAt')
 
     return (
-      <Loader loading={loading} error={error} render={() => {
-        const { commit, commit: { document: { meta } } } = repo
+      <div ref={this.containerRef}>
+        <Loader loading={loading} error={error} render={() => {
+          const { commit, commit: { document: { meta } } } = repo
 
-        const errors = [
-          !meta.slug && t('publish/validation/slug/empty'),
-          !meta.publishDate && t('publish/validation/publishDate/empty'),
-          (updateMailchimp && !meta.emailSubject) && t('publish/validation/emailSubject/empty')
-        ].filter(Boolean)
-        const hasErrors = errors.length > 0
+          const errors = [
+            !meta.slug && t('publish/validation/slug/empty'),
+            !meta.publishDate && t('publish/validation/publishDate/empty'),
+            (updateMailchimp && !meta.emailSubject) && t('publish/validation/emailSubject/empty')
+          ].filter(Boolean)
+          const hasErrors = errors.length > 0
 
-        const {
-          size,
-          css
-        } = this.state
+          const {
+            size,
+            css,
+            width
+          } = this.state
 
-        return (
-          <div>
-            <Label>{t('publish/commit/selected')}</Label>
-            <Interaction.P>
-              {commit.message}
-            </Interaction.P>
-            <Label>
-              {commit.author.name}<br />
-              {timeFormat(new Date(commit.date))}
-            </Label>
-            <Interaction.P>
+          const scale = width
+            ? Math.min(1, width / (size.width + PADDING_X * 2))
+            : 1
+
+          return (
+            <div>
+              <Label>{t('publish/commit/selected')}</Label>
+              <Interaction.P>
+                {commit.message}
+              </Interaction.P>
               <Label>
-                <Link
-                  route='repo/tree'
-                  params={{
-                    repoId: repoId.split('/')
+                {commit.author.name}<br />
+                {timeFormat(new Date(commit.date))}
+              </Label>
+              <Interaction.P>
+                <Label>
+                  <Link
+                    route='repo/tree'
+                    params={{
+                      repoId: repoId.split('/')
+                    }}
+                  >
+                    <a {...linkRule}>
+                      {t('publish/commit/change')}
+                    </a>
+                  </Link>
+                </Label>
+              </Interaction.P>
+
+              <br /><br />
+
+              {hasErrors && (
+                <Interaction.P style={{color: colors.error}}>
+                  {t('publish/validation/hasErrors')}
+                  <ul>
+                    {errors.map((error, i) => (
+                      <li key={i}>
+                        {error}
+                      </li>
+                    ))}
+                  </ul>
+                  <br /><br />
+                </Interaction.P>
+              )}
+
+              <Checkbox checked={prepublication} onChange={(_, value) => {
+                this.setState({
+                  prepublication: value
+                })
+              }}>
+                {t('publish/label/prepublication')}
+              </Checkbox>
+              <br />
+              <br />
+              <Checkbox checked={updateMailchimp} onChange={(_, value) => {
+                this.setState({
+                  updateMailchimp: value
+                })
+              }}>
+                {t('publish/label/updateMailchimp')}
+              </Checkbox>
+              <br />
+              <br />
+              <Checkbox checked={scheduled} onChange={(_, value) => {
+                this.setState({
+                  scheduled: value
+                })
+              }}>
+                {t('publish/label/scheduled')}
+              </Checkbox>
+
+              {scheduled && <Field
+                renderInput={(inputProps) => (
+                  <MaskedInput
+                    {...inputProps}
+                    {...styles.mask}
+                    placeholderChar={'_'}
+                    mask={'11.11.1111 11:11'} />
+                )}
+                label={t('publish/label/scheduledAt')}
+                value={scheduledAt}
+                error={scheduledAtError}
+                onChange={(_, value) => {
+                  this.setState({
+                    scheduledAt: value
+                  })
+                }} />}
+
+              <br /><br /><br />
+
+              {publishing ? (
+                <div style={{textAlign: 'center'}}>
+                  <InlineSpinner />
+                </div>
+              ) : (
+                <div>
+                  {!!this.state.error && (
+                    <ErrorMessage error={this.state.error} />
+                  )}
+                  <Button block primary disabled={hasErrors} onClick={() => {
+                    if (scheduled && scheduledAtError) {
+                      return
+                    }
+                    this.setState(() => ({publishing: true}))
+                    this.props.publish({
+                      repoId,
+                      commitId: commit.id,
+                      prepublication,
+                      updateMailchimp,
+                      scheduledAt: scheduled ? scheduledAtDate : undefined
+                    }).then(() => {
+                      Router.pushRoute('repo/tree', {
+                        repoId: repoId.split('/')
+                      })
+                    }).catch((error) => {
+                      this.setState(() => ({
+                        publishing: false,
+                        error: error
+                      }))
+                    })
+                  }}>
+                    {t('publish/trigger')}
+                  </Button>
+                </div>
+              )}
+              <br /><br />
+              <Interaction.H2>{t('publish/preview/title')}</Interaction.H2>
+
+              <Interaction.P>
+                {intersperse(
+                  PREVIEW_SIZES.map(previewSize => {
+                    const label = t(
+                      `publish/preview/${previewSize.label}`,
+                      undefined,
+                      previewSize.label
+                    )
+                    if (previewSize === size) {
+                      return [
+                        label,
+                        scale !== 1 && ` (${Math.round(scale * 10) / 10}x)`
+                      ].filter(Boolean).join(' ')
+                    }
+                    return (
+                      <A
+                        key={label}
+                        href='#'
+                        onClick={e => {
+                          e.preventDefault()
+                          this.setState({size: previewSize})
+                        }}
+                      >
+                        {label}
+                      </A>
+                    )
+                  }),
+                  () => ' '
+                )}
+              </Interaction.P>
+
+              <div style={{
+                // transition: 'padding 400ms, border-radius 400ms, width 400ms',
+                paddingLeft: PADDING_X,
+                paddingRight: PADDING_X,
+                paddingTop: size.paddingTop,
+                paddingBottom: size.paddingBottom,
+                borderRadius: size.borderRadius,
+                backgroundColor: '#eee',
+                width: size.width + PADDING_X * 2,
+                transformOrigin: '0% 0%',
+                transform: `scale(${scale})`
+              }}>
+                <Frame
+                  frameBorder='0'
+                  allowTransparency='true'
+                  contentDidMount={() => this.transferCSS()}
+                  head={[
+                    <style key='glamor'>{css}</style>
+                  ]}
+                  style={{
+                    width: '100%',
+                    height: size.height
                   }}
                 >
-                  <a {...linkRule}>
-                    {t('publish/commit/change')}
-                  </a>
-                </Link>
-              </Label>
-            </Interaction.P>
-
-            <br /><br />
-
-            {hasErrors && (
-              <Interaction.P style={{color: colors.error}}>
-                {t('publish/validation/hasErrors')}
-                <ul>
-                  {errors.map((error, i) => (
-                    <li key={i}>
-                      {error}
-                    </li>
-                  ))}
-                </ul>
-                <br /><br />
-              </Interaction.P>
-            )}
-
-            <Checkbox checked={prepublication} onChange={(_, value) => {
-              this.setState({
-                prepublication: value
-              })
-            }}>
-              {t('publish/label/prepublication')}
-            </Checkbox>
-            <br />
-            <br />
-            <Checkbox checked={updateMailchimp} onChange={(_, value) => {
-              this.setState({
-                updateMailchimp: value
-              })
-            }}>
-              {t('publish/label/updateMailchimp')}
-            </Checkbox>
-            <br />
-            <br />
-            <Checkbox checked={scheduled} onChange={(_, value) => {
-              this.setState({
-                scheduled: value
-              })
-            }}>
-              {t('publish/label/scheduled')}
-            </Checkbox>
-
-            {scheduled && <Field
-              renderInput={(inputProps) => (
-                <MaskedInput
-                  {...inputProps}
-                  {...styles.mask}
-                  placeholderChar={'_'}
-                  mask={'11.11.1111 11:11'} />
-              )}
-              label={t('publish/label/scheduledAt')}
-              value={scheduledAt}
-              error={scheduledAtError}
-              onChange={(_, value) => {
-                this.setState({
-                  scheduledAt: value
-                })
-              }} />}
-
-            <br /><br /><br />
-
-            {publishing ? (
-              <div style={{textAlign: 'center'}}>
-                <InlineSpinner />
+                  {renderMdast(commit.document.content, newsletterTemplate)}
+                </Frame>
               </div>
-            ) : (
-              <div>
-                {!!this.state.error && (
-                  <ErrorMessage error={this.state.error} />
-                )}
-                <Button block primary disabled={hasErrors} onClick={() => {
-                  if (scheduled && scheduledAtError) {
-                    return
-                  }
-                  this.setState(() => ({publishing: true}))
-                  this.props.publish({
-                    repoId,
-                    commitId: commit.id,
-                    prepublication,
-                    updateMailchimp,
-                    scheduledAt: scheduled ? scheduledAtDate : undefined
-                  }).then(() => {
-                    Router.pushRoute('repo/tree', {
-                      repoId: repoId.split('/')
-                    })
-                  }).catch((error) => {
-                    this.setState(() => ({
-                      publishing: false,
-                      error: error
-                    }))
-                  })
-                }}>
-                  {t('publish/trigger')}
-                </Button>
-              </div>
-            )}
-            <br /><br />
-            <Interaction.H2>Vorschau</Interaction.H2>
-
-            <Interaction.P>
-              {intersperse(
-                PREVIEW_SIZES.map(previewSize => {
-                  if (previewSize === size) {
-                    return previewSize.label
-                  }
-                  return (
-                    <A
-                      key={previewSize.label}
-                      href='#'
-                      onClick={e => {
-                        e.preventDefault()
-                        this.setState({size: previewSize})
-                      }}
-                    >
-                      {previewSize.label}
-                    </A>
-                  )
-                }),
-                () => ' '
-              )}
-            </Interaction.P>
-
-            <Frame
-              frameBorder='0'
-              allowTransparency='true'
-              contentDidMount={() => this.transferCSS()}
-              head={[
-                <style key='glamor'>{css}</style>
-              ]}
-              style={{
-                border: '1px solid black',
-                width: size.width,
-                height: size.height
-              }}
-            >
-              {renderMdast(commit.document.content, newsletterTemplate)}
-            </Frame>
-          </div>
-        )
-      }} />
+            </div>
+          )
+        }} />
+      </div>
     )
   }
 }

--- a/components/Templates/Newsletter/RBlueprint.js
+++ b/components/Templates/Newsletter/RBlueprint.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import {css} from 'glamor'
+
+const tableStyle = css({
+  borderSpacing: '20px 0',
+  '@media (max-width: 600px)': {
+    fontSize: 14
+  },
+  '@media (min-width: 321px) and (max-width: 600px)': {
+    borderSpacing: '10px 0'
+  },
+  '& th': {
+    fontStyle: 'italic'
+  },
+  '& th, & td': {
+    textAlign: 'left',
+    verticalAlign: 'top',
+    borderBottom: '1px solid #000',
+    paddingTop: 3,
+    paddingBottom: 20
+  },
+  '& tr:last-child th, & tr:last-child td': {
+    borderBottom: 'none'
+  }
+})
+const PADDING = 20
+
+export default () => (
+  <div style={{overflowX: 'auto', overflowY: 'hidden', marginLeft: -PADDING, marginRight: -PADDING}}>
+    <table {...tableStyle}>
+      <tbody>
+        <tr>
+          <th />
+          <td>
+            <img
+              style={{height: 40, marginBottom: 10}}
+              src='https://assets.project-r.construction/images/project_r_logo.svg' /><br />
+            Genossenschaft
+          </td>
+          <td>
+            <img
+              style={{height: 40, marginLeft: -10, marginBottom: 10}}
+              src='https://assets.project-r.construction/images/magazine_logo.png' /><br />
+            Aktiengesellschaft
+          </td>
+        </tr>
+        <tr>
+          <th>Name:</th>
+          <td>Project R</td>
+          <td>(noch ein Geheimnis)</td>
+        </tr>
+        <tr>
+          <th>Zweck:</th>
+          <td>
+            <p>Alles Institutionelle.</p>
+            <p>Dem Journalismus seine Rolle in der Demokratie sichern.</p>
+            <p>
+              <em>Gemeinnützig;</em><br />
+              mitglieder-, spenden- und stiftungsfinanziert
+            </p>
+          </td>
+          <td>
+            <p>Alles Journalistische.</p>
+            <p>Das digitale Magazin herstellen.</p>
+            <p>
+              <em>Gewinnorientiert</em><br />
+              (mit dem Ziel, mindestens selbsttragend zu werden)
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <th>Aufgaben:</th>
+          <td>
+            <p>Alles, was Journalismus schützt und voranbringt</p>
+            <ul>
+              <li>Entwicklung und Weiterentwicklung journalistischer Formate</li>
+              <li>Nachwuchsförderung, Aus- und Weiterbildung</li>
+              <li>Entwicklung IT-Infrastruktur (Open Source)</li>
+              <li>Veranstaltungen</li>
+              <li>Sensibilisierung von Öffentlichkeit für unabhängigen Journalismus</li>
+              <li>Mittelbeschaffung, Recherchefonds</li>
+              <li>Rechtliches</li>
+              <li>Kooperationen</li>
+            </ul>
+          </td>
+          <td>
+            <p>Journalismus</p>
+            <ul>
+              <li>Redaktion, Produktion und Vertrieb des digitalen Magazins</li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+)

--- a/components/Templates/Newsletter/index.js
+++ b/components/Templates/Newsletter/index.js
@@ -6,6 +6,7 @@ import { H2, H3 } from './Headlines'
 import Figure, { Image, Caption } from './Figure'
 import Blockquote from './Blockquote'
 import List, { ListItem } from './List'
+import RBlueprint from './RBlueprint'
 
 import {
   matchType,
@@ -133,6 +134,11 @@ const schema = {
               rules: [paragraph]
             }
           ]
+        },
+        {
+          matchMdast: matchZone('SPECIAL_R_BLUEPRINT'),
+          component: RBlueprint,
+          isVoid: true
         }
       ]
     }

--- a/components/Templates/utils.js
+++ b/components/Templates/utils.js
@@ -29,6 +29,10 @@ export const imageSizeInfo = url => {
 }
 
 export const imageResizeUrl = (url, size) => {
+  if (!url) {
+    return url
+  }
+
   const urlObject = parse(url, true)
   if (urlObject.protocol === 'data:') {
     return url

--- a/components/editor/NewsletterEditor.js
+++ b/components/editor/NewsletterEditor.js
@@ -52,6 +52,10 @@ import center, {
   serializer as centerSerializer, TYPE as CENTER
 } from './modules/center'
 
+import special, {
+  SpecialButton, SpecialForm
+} from './modules/special'
+
 const newsletterStyles = {
   fontFamily: 'serif',
   fontSize: 18,
@@ -230,7 +234,8 @@ const plugins = [
   ...cover.plugins,
   ...center.plugins,
   ...blockquote.plugins,
-  ...list.plugins
+  ...list.plugins,
+  ...special.plugins
 ]
 
 const textFormatButtons = [
@@ -249,13 +254,15 @@ const blockFormatButtons = [
 ]
 
 const insertButtons = [
-  FigureButton
+  FigureButton,
+  SpecialButton
 ]
 
 const propertyForms = [
   LinkForm,
   FigureForm,
-  CoverForm
+  CoverForm,
+  SpecialForm
 ]
 
 const Container = ({ children }) => (

--- a/components/editor/modules/center/index.js
+++ b/components/editor/modules/center/index.js
@@ -11,6 +11,7 @@ import headlines from '../headlines'
 import figure from '../figure'
 import blockquote from '../blockquote'
 import list from '../list'
+import special from '../special'
 
 const PADDING = 20
 const containerStyle = css({
@@ -38,7 +39,8 @@ const childSerializer = new MarkdownSerializer({
     ...figure.plugins,
     ...headlines.plugins,
     ...blockquote.plugins,
-    ...list.plugins
+    ...list.plugins,
+    ...special.plugins
   ])
 })
 

--- a/components/editor/modules/special/constants.js
+++ b/components/editor/modules/special/constants.js
@@ -1,0 +1,1 @@
+export const CUSTOM = 'CUSTOM'

--- a/components/editor/modules/special/index.js
+++ b/components/editor/modules/special/index.js
@@ -1,0 +1,74 @@
+import { matchBlock } from '../../utils'
+import { CUSTOM } from './constants'
+import { colors } from '@project-r/styleguide'
+import { Block } from 'slate'
+import { SpecialButton, SpecialForm } from './ui'
+
+const zone = {
+  match: matchBlock(CUSTOM),
+  matchMdast: (node) => node.type === 'zone',
+  fromMdast: (node, index, parent, visitChildren) => {
+    return {
+      kind: 'block',
+      type: CUSTOM,
+      data: {
+        identifier: node.identifier,
+        ...node.data
+      },
+      isVoid: true
+    }
+  },
+  toMdast: (object, index, parent, visitChildren, context) => {
+    const {identifier, ...data} = object.data
+    return {
+      type: 'zone',
+      identifier,
+      data: data,
+      children: []
+    }
+  },
+  render: ({ node, state }) => {
+    const active = state.blocks.some(block => block.key === node.key)
+    return (
+      <div style={{
+        width: '100%',
+        height: '20vh',
+        paddingTop: '8vh',
+        textAlign: 'center',
+        backgroundColor: colors.primaryBg,
+        transition: 'outline-color 0.2s',
+        outline: '4px solid transparent',
+        outlineColor: active ? colors.primary : 'transparent',
+        marginBottom: 10
+      }}>
+        {node.data.get('identifier') || 'Special'}
+      </div>
+    )
+  }
+}
+
+export const newBlock = () => Block.fromJSON(
+  zone.fromMdast({
+    type: 'zone',
+    identifier: 'SPECIAL',
+    data: {}
+  })
+)
+
+export {
+  CUSTOM,
+  SpecialButton,
+  SpecialForm
+}
+
+export default {
+  plugins: [
+    {
+      schema: {
+        rules: [
+          zone
+        ]
+      }
+    }
+  ]
+}

--- a/components/editor/modules/special/ui.js
+++ b/components/editor/modules/special/ui.js
@@ -1,0 +1,86 @@
+import React from 'react'
+import { css } from 'glamor'
+
+import styles from '../../styles'
+import { Label } from '@project-r/styleguide'
+import { Map } from 'immutable'
+
+import {
+  matchBlock,
+  createPropertyForm,
+  createActionButton
+} from '../../utils'
+import injectBlock from '../../utils/injectBlock'
+import MetaForm from '../../utils/MetaForm'
+
+import { CUSTOM } from './constants'
+import { newBlock } from './'
+
+export const SpecialButton = createActionButton({
+  isDisabled: ({ state }) => {
+    return state.isBlurred
+  },
+  reducer: ({ state, onChange }) => event => {
+    event.preventDefault()
+
+    return onChange(
+      state
+        .change()
+        .call(
+          injectBlock,
+          newBlock()
+        )
+    )
+  }
+})(
+  ({ disabled, visible, ...props }) =>
+    <span
+      {...css(styles.insertButton)}
+      {...props}
+      data-disabled={disabled}
+      data-visible={visible}
+      >
+      Special
+    </span>
+)
+
+const Form = ({ disabled, state, onChange }) => {
+  if (disabled) {
+    return null
+  }
+  return <div>
+    <Label>Special</Label>
+    {
+      state.blocks
+        .filter(matchBlock(CUSTOM))
+        .map((node, i) => {
+          const onInputChange = key => (_, value) => {
+            onChange(
+              state
+                .change()
+                .setNodeByKey(node.key, {
+                  data: value
+                    ? node.data.set(key, value)
+                    : node.data.remove(key)
+                })
+            )
+          }
+          return (
+            <MetaForm
+              key={`special-${i}`}
+              data={Map({
+                identifier: ''
+              }).merge(node.data)}
+              onInputChange={onInputChange}
+            />
+          )
+        })
+    }
+  </div>
+}
+
+export const SpecialForm = createPropertyForm({
+  isDisabled: ({ state }) => {
+    return !state.blocks.some(matchBlock(CUSTOM))
+  }
+})(Form)

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-10-04T09:46:02.969Z",
+  "updated": "2017-10-10T20:37:53.718Z",
   "title": "live",
   "data": [
     {
@@ -284,7 +284,19 @@
     },
     {
       "key": "publish/title",
-      "value": "Vorschau und Veröffentlichung"
+      "value": "Veröffentlichung"
+    },
+    {
+      "key": "publish/preview/title",
+      "value": "Vorschau"
+    },
+    {
+      "key": "publish/preview/mobile",
+      "value": "Mobile"
+    },
+    {
+      "key": "publish/preview/desktop",
+      "value": "Desktop"
     },
     {
       "key": "publish/commit/selected",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6451,6 +6451,11 @@
         "prop-types": "15.5.10"
       }
     },
+    "react-frame-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-1.1.1.tgz",
+      "integrity": "sha1-Bbf1aJotNz8luvDJrbDlnXgQM4g="
+    },
     "react-hot-loader": {
       "version": "3.0.0-beta.7",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.7.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "^15.6.1",
     "react-apollo": "^1.4.15",
     "react-dom": "^15.6.1",
+    "react-frame-component": "^1.1.1",
     "react-icons": "^2.2.5",
     "react-maskedinput": "^4.0.0",
     "react-portal": "^3.1.0",

--- a/pages/repo/publish.js
+++ b/pages/repo/publish.js
@@ -14,7 +14,6 @@ const Page = ({ url, data, t }) => {
   return (
     <Frame url={url} nav={<RepoNav route='repo/publish' url={url} />}>
       <h1>{t('publish/title')}</h1>
-
       <PublishForm repoId={repoId} commitId={commitId} t={t} />
     </Frame>
   )


### PR DESCRIPTION
Allow to create arbitrary special placeholder in the editor with a key:
<img width="1010" alt="screen shot 2017-10-10 at 16 53 56" src="https://user-images.githubusercontent.com/410211/31393281-aa93692c-addb-11e7-9f30-d07374a05188.png">

To then render this one need to catch this key in the templates:
https://github.com/orbiting/publikator-frontend/commit/eb4e99bc63a813215f7b6e924f519af1352ff592

Things for another time
- a dynamic special registry to avoid extending the template
  - js files in git compiled by our backend?
  - zeit hinted at some new development re es modules in next and it seems to take care of transpilation, maybe there is something brewing
  - the hard thing is solving dependencies

Bonus, a preview mode in the publish form:
<img width="678" alt="screen shot 2017-10-10 at 23 51 55" src="https://user-images.githubusercontent.com/410211/31412627-2011f2ba-ae16-11e7-937b-625fff1f785c.png">
