### PR TITLE
Bump slate again

### DIFF
--- a/components/editor/Placeholder.js
+++ b/components/editor/Placeholder.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default ({children}) => {
+  const style = {
+    position: 'absolute',
+    top: '0px',
+    right: '0px',
+    bottom: '0px',
+    left: '0px',
+    pointerEvents: 'none',
+    opacity: '0.333'
+  }
+
+  return (
+    <span contentEditable={false} style={style}>
+      {children}
+    </span>
+  )
+}

--- a/components/editor/modules/blockquote/index.js
+++ b/components/editor/modules/blockquote/index.js
@@ -40,7 +40,7 @@ export {
 export default {
   plugins: [
     {
-      onKeyDown (event, data, change) {
+      onKeyDown (event, change) {
         const isBackspace = event.key === 'Backspace'
         if (event.key !== 'Enter' && !isBackspace) return
 

--- a/components/editor/modules/blockquote/index.js
+++ b/components/editor/modules/blockquote/index.js
@@ -41,8 +41,8 @@ export default {
   plugins: [
     {
       onKeyDown (event, data, change) {
-        const isBackspace = data.key === 'backspace'
-        if (data.key !== 'enter' && !isBackspace) return
+        const isBackspace = event.key === 'Backspace'
+        if (event.key !== 'Enter' && !isBackspace) return
 
         const { state } = change
         const inBlockquote = state.document.getClosest(

--- a/components/editor/modules/figure/index.js
+++ b/components/editor/modules/figure/index.js
@@ -243,7 +243,7 @@ export {
 export default {
   plugins: [
     {
-      onKeyDown (event, data, change) {
+      onKeyDown (event, change) {
         const isBackspace = event.key === 'Backspace'
         if (event.key !== 'Enter' && !isBackspace) return
 

--- a/components/editor/modules/figure/index.js
+++ b/components/editor/modules/figure/index.js
@@ -244,8 +244,8 @@ export default {
   plugins: [
     {
       onKeyDown (event, data, change) {
-        const isBackspace = data.key === 'backspace'
-        if (data.key !== 'enter' && !isBackspace) return
+        const isBackspace = event.key === 'Backspace'
+        if (event.key !== 'Enter' && !isBackspace) return
 
         const { state } = change
         const inFigure = state.document.getClosest(

--- a/components/editor/modules/figure/index.js
+++ b/components/editor/modules/figure/index.js
@@ -8,7 +8,7 @@ import addValidation, { findOrCreate } from '../../utils/serializationValidation
 import { gray2x1 } from '../../utils/placeholder'
 import { serializer as paragraphSerializer, PARAGRAPH } from '../paragraph'
 import { Block } from 'slate'
-import { Placeholder } from 'slate-react'
+import Placeholder from '../../Placeholder'
 import { imageResizeUrl } from '../../../Templates/utils'
 
 import MarkdownSerializer from '../../../../lib/serializer'
@@ -74,6 +74,11 @@ const figureCaption = {
       nodes: object.nodes
     }).children
   }),
+  placeholder: ({node}) => {
+    if (node.text.length) return null
+
+    return <Placeholder>Legende</Placeholder>
+  },
   render: (props) => {
     return (
       <figcaption style={{
@@ -85,13 +90,6 @@ const figureCaption = {
         margin: 0,
         position: 'relative'
       }}>
-        <Placeholder
-          state={props.state}
-          node={props.node}
-          firstOnly={false}
-        >
-          Legende
-        </Placeholder>
         {props.children}
       </figcaption>
     )

--- a/components/editor/modules/headlines/index.js
+++ b/components/editor/modules/headlines/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { css } from 'glamor'
-import { Placeholder } from 'slate-react'
 import MarkdownSerializer from '../../../../lib/serializer'
+import Placeholder from '../../Placeholder'
 
 import { matchBlock } from '../../utils'
 import {
@@ -47,14 +47,13 @@ export const title = {
     depth: 1,
     children: visitChildren(object)
   }),
+  placeholder: ({node}) => {
+    if (node.text.length) return null
+
+    return <Placeholder>Titel</Placeholder>
+  },
   render: ({ children, ...props }) =>
     <h1 {...css(styles.base)} {...css(styles.h1)}>
-      <Placeholder
-        state={props.state}
-        node={props.node}
-        firstOnly={false}>
-        Titel
-      </Placeholder>
       { children }
     </h1>
 }

--- a/components/editor/modules/lead/index.js
+++ b/components/editor/modules/lead/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { css } from 'glamor'
-import { Placeholder } from 'slate-react'
+import Placeholder from '../../Placeholder'
 import { matchBlock } from '../../utils'
 import { LEAD } from './constants'
-// import { mq } from '../../styles'
+
 import MarkdownSerializer from '../../../../lib/serializer'
 import {serializer as paragraphSerializer, PARAGRAPH} from '../paragraph'
 
@@ -35,15 +35,13 @@ const lead = {
       })
     ]
   }),
+  placeholder: ({node}) => {
+    if (node.text.length) return null
+
+    return <Placeholder>Lead</Placeholder>
+  },
   render: ({ children, ...props }) =>
     <p {...css(styles.lead)}>
-      <Placeholder
-        state={props.state}
-        node={props.node}
-        firstOnly={false}
-      >
-        Lead
-      </Placeholder>
       {children}
     </p>
 }

--- a/components/editor/modules/list/index.js
+++ b/components/editor/modules/list/index.js
@@ -98,8 +98,8 @@ export default {
   plugins: [
     {
       onKeyDown (event, data, change) {
-        const isBackspace = data.key === 'backspace'
-        if (data.key !== 'enter' && !isBackspace) return
+        const isBackspace = event.key === 'Backspace'
+        if (event.key !== 'Enter' && !isBackspace) return
 
         const { state } = change
         const inList = state.document.getClosest(state.startBlock.key, matchBlock(LIST))

--- a/components/editor/modules/list/index.js
+++ b/components/editor/modules/list/index.js
@@ -97,7 +97,7 @@ export {
 export default {
   plugins: [
     {
-      onKeyDown (event, data, change) {
+      onKeyDown (event, change) {
         const isBackspace = event.key === 'Backspace'
         if (event.key !== 'Enter' && !isBackspace) return
 

--- a/components/editor/modules/paragraph/index.js
+++ b/components/editor/modules/paragraph/index.js
@@ -25,7 +25,7 @@ const inlineSerializer = new MarkdownSerializer({
     matchMdast: (node) => node.type === 'break',
     fromMdast: (node, index, parent, visitChildren) => ({
       kind: 'text',
-      ranges: [{text: '\n'}]
+      leaves: [{text: '\n'}]
     })
   })
 })
@@ -59,7 +59,7 @@ export {
 export default {
   plugins: [
     {
-      onKeyDown (e, data, change) {
+      onKeyDown (e, change) {
         const { state } = change
         if (e.key !== 'Enter') return
         if (e.shiftKey === false) return

--- a/components/editor/modules/paragraph/index.js
+++ b/components/editor/modules/paragraph/index.js
@@ -61,7 +61,7 @@ export default {
     {
       onKeyDown (e, data, change) {
         const { state } = change
-        if (data.key !== 'enter') return
+        if (e.key !== 'Enter') return
         if (e.shiftKey === false) return
 
         const { startBlock } = state

--- a/components/editor/utils/createBlockButton.test.js
+++ b/components/editor/utils/createBlockButton.test.js
@@ -13,7 +13,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'Hello BlockButton!'
             }
@@ -27,7 +27,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'We are blocks at your service.'
             }
@@ -41,7 +41,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'Tamper with us'
             }

--- a/components/editor/utils/createInlineButton.test.js
+++ b/components/editor/utils/createInlineButton.test.js
@@ -13,7 +13,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'Hello MarkButton!'
             }
@@ -27,7 +27,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'We are blocks at your service.'
             }
@@ -41,7 +41,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'Tamper with us'
             }

--- a/components/editor/utils/createMarkButton.test.js
+++ b/components/editor/utils/createMarkButton.test.js
@@ -13,7 +13,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'Hello MarkButton!'
             }
@@ -27,7 +27,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'We are blocks at your service.'
             }
@@ -41,7 +41,7 @@ const rawDoc = {
       nodes: [
         {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
               text: 'Tamper with us'
             }

--- a/lib/serializer/index.js
+++ b/lib/serializer/index.js
@@ -107,23 +107,23 @@ class MarkdownSerializer {
     console.warn('Missing toMdast', node)
     return visitChildren(node)
   }) {
-    const visitRanges = (ranges, parent) => {
-      if (!ranges.length) {
+    const visitLeaves = (leaves, parent) => {
+      if (!leaves.length) {
         return []
       }
 
-      const firstMark = ranges[0].marks[0]
+      const firstMark = leaves[0].marks[0]
       if (firstMark) {
         let markEndIndex = 1
-        while (ranges[markEndIndex] && ranges[markEndIndex].marks.find(mark => equals(mark, firstMark))) {
+        while (leaves[markEndIndex] && leaves[markEndIndex].marks.find(mark => equals(mark, firstMark))) {
           markEndIndex += 1
         }
 
         return []
           .concat(
             visit(firstMark, 0, parent, () => {
-              return visitRanges(
-                ranges.slice(0, markEndIndex).map(range => {
+              return visitLeaves(
+                leaves.slice(0, markEndIndex).map(range => {
                   return Object.assign({}, range, {
                     marks: range.marks.filter(mark => !equals(mark, firstMark))
                   })
@@ -132,10 +132,10 @@ class MarkdownSerializer {
               )
             })
           )
-          .concat(visitRanges(ranges.slice(markEndIndex), parent))
+          .concat(visitLeaves(leaves.slice(markEndIndex), parent))
       }
 
-      let texts = ranges[0].text.split('\n').map(text => ({
+      let texts = leaves[0].text.split('\n').map(text => ({
         type: 'text',
         value: text
       }))
@@ -151,13 +151,13 @@ class MarkdownSerializer {
       }
 
       return texts
-        .concat(visitRanges(ranges.slice(1), parent))
+        .concat(visitLeaves(leaves.slice(1), parent))
     }
     const visitArray = (nodes, parent) => {
       return nodes.reduce((children, child, i) => {
         if (child.kind === 'text') {
           return children.concat(
-            visitRanges(child.ranges, child)
+            visitLeaves(child.leaves, child)
           )
         }
 
@@ -205,7 +205,7 @@ class MarkdownSerializer {
         (compact, node) => {
           const prev = compact[compact.length - 1]
           if (prev && prev.kind === 'text' && node.kind === 'text') {
-            prev.ranges = prev.ranges.concat(node.ranges)
+            prev.leaves = prev.leaves.concat(node.leaves)
             return compact
           }
           compact.push(node)
@@ -232,7 +232,7 @@ class MarkdownSerializer {
         if (node.kind === 'mark') {
           return deserializeMark(node)
         } else if (node.kind === 'text') {
-          node.ranges = node.ranges.map((range) => {
+          node.leaves = node.leaves.map((range) => {
             range.marks.unshift({
               kind: 'mark',
               type,
@@ -256,9 +256,9 @@ class MarkdownSerializer {
       if (node.type === 'text') {
         return {
           kind: 'text',
-          ranges: [
+          leaves: [
             {
-              kind: 'range',
+              kind: 'leaf',
               text: node.value,
               marks: []
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4574,6 +4574,11 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
       "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
     },
+    "is-hotkey": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.0.3.tgz",
+      "integrity": "sha512-qpMe/7DxFXs65E3f8u5Zu+3qOXmqlKlAF/cpYlRiPzg1UKC9clzQcwcuf/2RC4WMFhh56DQC+FfK63Qp3lM35w=="
+    },
     "is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
@@ -6505,6 +6510,11 @@
         "react-icon-base": "2.0.7"
       }
     },
+    "react-immutable-proptypes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz",
+      "integrity": "sha1-Aj1vObsVyXwHHp5g0A0TbqxfoLQ="
+    },
     "react-maskedinput": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/react-maskedinput/-/react-maskedinput-4.0.0.tgz",
@@ -7118,9 +7128,9 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slate": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.25.1.tgz",
-      "integrity": "sha512-4VxNVLY8r+d5thRCrkcMYgor58LRwJTXGx8fvxbGxJuw8cFlfAZLfr10N/g/jNzEklagoTLI6Jvhm6gWvrhngQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.27.4.tgz",
+      "integrity": "sha512-TjYTThrin/Vo85KOVaBy/t2T3uuaKEpucmsHH8hCWnbkSavBKYoghPUlZ7EcqXv0iOgzdAu9/kRv1Icsmwy+Dg==",
       "requires": {
         "debug": "2.6.8",
         "direction": "0.1.5",
@@ -7129,53 +7139,62 @@
         "is-empty": "1.2.0",
         "is-plain-object": "2.0.4",
         "lodash": "4.17.4",
-        "slate-dev-logger": "0.1.9",
+        "slate-dev-logger": "0.1.19",
         "type-of": "2.0.1"
+      },
+      "dependencies": {
+        "slate-dev-logger": {
+          "version": "0.1.19",
+          "resolved": "https://registry.npmjs.org/slate-dev-logger/-/slate-dev-logger-0.1.19.tgz",
+          "integrity": "sha512-ANU0rY1d60CXX89Xi7nO93xQ2hIG0YbHXYg4OjaVu5XJ7E5D5Ek+6AlohfjN6CtMutympf4hsSlVB5KUZ0nQbA=="
+        }
       }
     },
     "slate-base64-serializer": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.1.8.tgz",
-      "integrity": "sha512-wy3lI7Qu0Sl6mW85C2+QooCe5h+jVtoPKij5T0lyW3oAg+FsQPH5Z9RD2zFiiLhPQ4r2XQLcuHKfo/HANcri/Q=="
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.1.18.tgz",
+      "integrity": "sha512-TWUOtY+3FEbtFUwx5qq1S0LLKK9ZZhzUI2hnbpVxzVPn30CwlLXRn2oWBwi++I2wMKynPKcoBK7hkSnK6nGQVQ=="
     },
     "slate-dev-logger": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/slate-dev-logger/-/slate-dev-logger-0.1.9.tgz",
-      "integrity": "sha512-waTqfHbOaIextQQ5DTzQaWO6lT463a7PYc+aB4ml5xkbNPONr4konYFJe39uJzCJ2aJ9SljnqqJYQi5v0rcEUQ=="
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/slate-dev-logger/-/slate-dev-logger-0.1.19.tgz",
+      "integrity": "sha512-ANU0rY1d60CXX89Xi7nO93xQ2hIG0YbHXYg4OjaVu5XJ7E5D5Ek+6AlohfjN6CtMutympf4hsSlVB5KUZ0nQbA=="
     },
     "slate-plain-serializer": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.1.8.tgz",
-      "integrity": "sha512-R8eFevJEMFPjBxPoRsRVmxniFWR09YQj21dBvj/cuOTCAHE9QdWjAxQ2RuJN+YAN0zG1z1va60E/1wypIj0p0w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.2.4.tgz",
+      "integrity": "sha512-ls7ReboLPQu0Ai1wwonUWfqe0JdQcaK4UVREvA6MpbxT7RhAIsAHECnj/l9kJwhsxo/53jdYed6/fZbQuiuGHw==",
       "requires": {
-        "slate-dev-logger": "0.1.9"
+        "slate-dev-logger": "0.1.19"
       }
     },
     "slate-prop-types": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.1.8.tgz",
-      "integrity": "sha512-l3ag8LU+VG2chPMnM8FPyFVSKlnlXG0YC+L2s/TganPcdSn2ChCdjMAqo37xYvSlH0VqdLn1PRMvty3BN0Xuvw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.2.4.tgz",
+      "integrity": "sha512-PEEYpKPW5moM0lmKNZjMKLZBl5Mt5403rrFdOk6Re1Udh0nvrVcCdxknjyxM4oC+kOQa6QJANvzSx1O7hFiM4A==",
       "requires": {
-        "slate-dev-logger": "0.1.9"
+        "slate-dev-logger": "0.1.19"
       }
     },
     "slate-react": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.1.8.tgz",
-      "integrity": "sha512-P6VsdhTLuEYl1IlJiEoXJsaFKyFag38d5onzcjTXtiSM70rdK9WrIpiz4za9bXXePg+V5TH4MUU4tDox7HP7lw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.6.0.tgz",
+      "integrity": "sha512-jJylzzpqm27Z4sC/sdKM9i83QXCQKBkECRKxKsMRZPMW7QguOaxAcn1exhLN8+2teVaVrpaPrr/Bi81/z3I5TA==",
       "requires": {
         "debug": "2.6.8",
         "get-window": "1.1.1",
+        "is-hotkey": "0.0.3",
         "is-in-browser": "1.1.3",
         "is-window": "1.0.2",
         "keycode": "2.1.9",
         "prop-types": "15.5.10",
+        "react-immutable-proptypes": "2.1.0",
         "react-portal": "3.1.0",
         "selection-is-backward": "1.0.0",
-        "slate-base64-serializer": "0.1.8",
-        "slate-dev-logger": "0.1.9",
-        "slate-plain-serializer": "0.1.8",
-        "slate-prop-types": "0.1.8"
+        "slate-base64-serializer": "0.1.18",
+        "slate-dev-logger": "0.1.19",
+        "slate-plain-serializer": "0.2.4",
+        "slate-prop-types": "0.2.4"
       }
     },
     "slice-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4575,9 +4575,9 @@
       "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
     },
     "is-hotkey": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.0.3.tgz",
-      "integrity": "sha512-qpMe/7DxFXs65E3f8u5Zu+3qOXmqlKlAF/cpYlRiPzg1UKC9clzQcwcuf/2RC4WMFhh56DQC+FfK63Qp3lM35w=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.1.tgz",
+      "integrity": "sha512-ebDPnsc4Lw9O7GpnJkpNIuEJVjsFg1X60+5omHfFg9y1S4r6qwddENg0vHqtmWxsu/D8DGbAb5jjLzRZs0NMbA=="
     },
     "is-in-browser": {
       "version": "1.1.3",
@@ -7177,13 +7177,13 @@
       }
     },
     "slate-react": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.6.0.tgz",
-      "integrity": "sha512-jJylzzpqm27Z4sC/sdKM9i83QXCQKBkECRKxKsMRZPMW7QguOaxAcn1exhLN8+2teVaVrpaPrr/Bi81/z3I5TA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.7.2.tgz",
+      "integrity": "sha512-efXXVoUURlwMyyMwTZeJ0xMqO7cCOTS0Fy/6NazZOMgSSfQgI0VNloJR0O8Fu8q8VKwltetSzb8Cw3T8JzPM1Q==",
       "requires": {
         "debug": "2.6.8",
         "get-window": "1.1.1",
-        "is-hotkey": "0.0.3",
+        "is-hotkey": "0.1.1",
         "is-in-browser": "1.1.3",
         "is-window": "1.0.2",
         "keycode": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "remark-frontmatter": "^1.1.0",
     "remark-parse": "^4.0.0",
     "remark-stringify": "^4.0.0",
-    "slate": "^0.25.1",
-    "slate-react": "^0.1.8",
+    "slate": "^0.27.4",
+    "slate-react": "^0.6.0",
     "subscriptions-transport-ws": "^0.8.2",
     "unified": "^6.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "remark-parse": "^4.0.0",
     "remark-stringify": "^4.0.0",
     "slate": "^0.27.4",
-    "slate-react": "^0.6.0",
+    "slate-react": "^0.7.2",
     "subscriptions-transport-ws": "^0.8.2",
     "unified": "^6.1.5"
   }


### PR DESCRIPTION
Next round of breaking changes in slate.

A nice little change in slate-react: placeholder can now be defined on the schema just like render functions. Skipping pointer events, `contentEditable={false}`, styling and simple node based display logic is now in our code base again. Signature in slate plugin event handlers has changes—[(slate event) data is gone](https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/Changelog.md#deprecated)—replaced `data.key`with `event.key`. 

The change in core that affects us is [text ranges are now called leaves](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/Changelog.md#breaking). I haven't truly wrapped my head around why that makes sense but renaming was mostly easy.