### PR TITLE
Templates

### DIFF
--- a/components/Repo/List.js
+++ b/components/Repo/List.js
@@ -26,6 +26,10 @@ const styles = {
     flexFlow: 'row wrap',
     margin: '0 auto'
   }),
+  select: css({
+    width: '100%',
+    margin: '10px 0 0'
+  }),
   input: css({
     width: '100%',
     [mediaQueries.mUp]: {
@@ -47,13 +51,14 @@ class RepoList extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      title: ''
+      title: '',
+      template: ''
     }
   }
   onSubmit (event) {
     event.preventDefault()
 
-    const { title, error } = this.state
+    const { title, template, error } = this.state
     if (error || !title) {
       this.handleTitle(title, true)
       return
@@ -66,7 +71,8 @@ class RepoList extends Component {
     Router.replaceRoute('repo/edit', {
       repoId: [GITHUB_ORG, slug],
       commitId: 'new',
-      title
+      title,
+      template
     })
   }
   handleTitle (value, shouldValidate) {
@@ -82,7 +88,7 @@ class RepoList extends Component {
   }
   render () {
     const { t, data } = this.props
-    const { title, dirty, error } = this.state
+    const { title, template, dirty, error } = this.state
     return (
       <Loader loading={data.loading} error={data.error} render={() => (
         <div>
@@ -105,6 +111,14 @@ class RepoList extends Component {
 
           <Interaction.H2>{t('repo/list/add/title')}</Interaction.H2>
           <form {...styles.form} onSubmit={e => this.onSubmit(e)}>
+            <div {...styles.select}>
+              <select value={template} onChange={e => {
+                this.setState({template: e.target.value})
+              }}>
+                <option value='newsletter'>Newsletter</option>
+                <option value='neutrum'>Neutrum</option>
+              </select>
+            </div>
             <div {...styles.input}>
               <Field
                 label={t('repo/list/add/titleField/label')}

--- a/components/Templates/Neutrum/index.js
+++ b/components/Templates/Neutrum/index.js
@@ -1,0 +1,127 @@
+import {
+  matchType,
+  matchZone,
+  matchHeading,
+  matchParagraph
+} from '../utils'
+
+import {
+  H1, H2,
+  P, A, NarrowContainer
+} from '@project-r/styleguide'
+
+const Br = () => <br />
+const Strong = ({ children, attributes = {} }) =>
+  <strong {...attributes}>{ children }</strong>
+const Em = ({ children, attributes = {} }) =>
+  <em {...attributes}>{ children }</em>
+const Del = ({ children, attributes = {} }) =>
+  <del {...attributes}>{ children }</del>
+
+const paragraph = {
+  matchMdast: matchParagraph,
+  component: ({ children, attributes = {} }) =>
+    <P {...attributes}>{children}</P>,
+  editorModule: 'paragraph',
+  editorOptions: {
+    formatButtonText: 'Paragraph'
+  },
+  rules: [
+    {
+      matchMdast: matchType('break'),
+      component: Br,
+      isVoid: true
+    },
+    {
+      matchMdast: matchType('strong'),
+      component: Strong,
+      editorModule: 'mark',
+      editorOptions: {
+        type: 'strong'
+      }
+    },
+    {
+      matchMdast: matchType('emphasis'),
+      component: Em,
+      editorModule: 'mark',
+      editorOptions: {
+        type: 'emphasis'
+      }
+    },
+    {
+      matchMdast: matchType('delete'),
+      component: Del,
+      editorModule: 'mark',
+      editorOptions: {
+        type: 'delete'
+      }
+    },
+    {
+      matchMdast: matchType('link'),
+      getData: node => ({
+        title: node.title,
+        href: node.url
+      }),
+      component: ({ children, data, attributes = {} }) =>
+        <A
+          href={data.href}
+          title={data.title}
+          {...attributes}>
+          {children}
+        </A>,
+      editorModule: 'link'
+    }
+  ]
+}
+
+const schema = {
+  rules: [
+    {
+      matchMdast: matchType('root'),
+      component: ({ children, attributes = {} }) =>
+        <div {...attributes} style={{padding: '20px 0'}}>{children}</div>,
+      editorModule: 'documentPlain',
+      rules: [
+        {
+          matchMdast: matchZone(
+            'CENTER'
+          ),
+          component: ({ children, attributes = {} }) =>
+            <NarrowContainer {...attributes}>{children}</NarrowContainer>,
+          editorModule: 'center',
+          rules: [
+            paragraph,
+            {
+              matchMdast: matchHeading(
+                2
+              ),
+              component: H1,
+              editorModule: 'headline',
+              editorOptions: {
+                type: 'h1',
+                depth: 1,
+                formatButtonText:
+                  'Zwischentitel 1'
+              }
+            },
+            {
+              matchMdast: matchHeading(
+                3
+              ),
+              component: H2,
+              editorModule: 'headline',
+              editorOptions: {
+                type: 'h2',
+                depth: 2,
+                formatButtonText:
+                  'Zwischentitel 2'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+export default schema

--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -9,6 +9,7 @@ import Sidebar from './Sidebar'
 import MetaData from './modules/meta/ui'
 
 import createDocumentModule from './modules/document'
+import createDocumentPlainModule from './modules/document/plain'
 import createCoverModule from './modules/cover'
 import createCenterModule from './modules/center'
 import createHeadlineModule from './modules/headline'
@@ -24,6 +25,7 @@ import createSpecialModule from './modules/special'
 
 const moduleCreators = {
   document: createDocumentModule,
+  documentPlain: createDocumentPlainModule,
   cover: createCoverModule,
   center: createCenterModule,
   headline: createHeadlineModule,

--- a/components/editor/modules/center/index.js
+++ b/components/editor/modules/center/index.js
@@ -38,12 +38,15 @@ export default ({rule, subModules, TYPE}) => {
     ]
   })
 
+  const newDocument = ({title}) => serializer.deserialize(`# ${title}\n\n`)
+
   const Center = rule.component
 
   return {
     TYPE,
     helpers: {
-      serializer
+      serializer,
+      newDocument
     },
     changes: {},
     plugins: [

--- a/components/editor/modules/document/plain.js
+++ b/components/editor/modules/document/plain.js
@@ -1,0 +1,164 @@
+import { Document as SlateDocument } from 'slate'
+
+import MarkdownSerializer from '../../../../lib/serializer'
+import { findOrCreate } from '../../utils/serialization'
+
+export default ({rule, subModules, TYPE}) => {
+  const centerModule = subModules.find(m => m.name === 'center')
+  if (!centerModule) {
+    throw new Error('Missing center submodule')
+  }
+
+  const centerSerializer = centerModule.helpers.serializer
+
+  const autoMeta = documentNode => {
+    const data = documentNode.data
+    const autoMeta = !data || !data.size || data.get('auto')
+    if (!autoMeta) {
+      return null
+    }
+    const center = documentNode.nodes
+      .find(n => n.type === centerModule.TYPE && n.kind === 'block')
+    if (!center) {
+      return null
+    }
+    const title = center.first()
+
+    const newData = data
+      .set('auto', true)
+      .set('title', title ? title.text : '')
+
+    return data.equals(newData)
+      ? null
+      : newData
+  }
+
+  const documentRule = {
+    match: object => object.kind === 'document',
+    matchMdast: rule.matchMdast,
+    fromMdast: (node, index, parent, visitChildren) => {
+      let center = findOrCreate(node.children, {
+        type: 'zone', identifier: centerModule.TYPE
+      }, {
+        children: []
+      })
+
+      const centerIndex = node.children.indexOf(center)
+      const before = []
+      const after = []
+      node.children.forEach((child, index) => {
+        if (child !== center) {
+          if (index > centerIndex) {
+            after.push(child)
+          } else {
+            before.push(child)
+          }
+        }
+      })
+      if (before.length || after.length) {
+        center = {
+          ...center,
+          children: [
+            ...before,
+            ...center.children,
+            ...after
+          ]
+        }
+      }
+
+      const documentNode = {
+        data: node.meta,
+        kind: 'document',
+        nodes: [
+          centerSerializer.fromMdast(center)
+        ]
+      }
+
+      const newData = autoMeta(
+        SlateDocument.fromJSON(documentNode)
+      )
+      if (newData) {
+        documentNode.data = newData.toJS()
+      }
+
+      return {
+        document: documentNode,
+        kind: 'value'
+      }
+    },
+    toMdast: (object, index, parent, visitChildren, context) => {
+      const center = findOrCreate(
+        object.nodes,
+        { kind: 'block', type: centerModule.TYPE },
+        { nodes: [] }
+      )
+
+      return {
+        type: 'root',
+        meta: object.data,
+        children: [
+          centerSerializer.toMdast(center)
+        ]
+      }
+    }
+  }
+
+  const serializer = new MarkdownSerializer({
+    rules: [
+      documentRule
+    ]
+  })
+
+  const newDocument = ({title, template}) => serializer.deserialize(
+`---
+template: ${template}
+---
+
+<section><h6>${centerModule.TYPE}</h6>
+
+# ${title}
+
+Hurray!
+
+<hr/></section>
+`
+  )
+
+  const Container = rule.component
+
+  return {
+    TYPE,
+    helpers: {
+      serializer,
+      newDocument
+    },
+    changes: {},
+    plugins: [
+      {
+        renderEditor: ({children}) => <Container>{children}</Container>,
+        schema: {
+          document: {
+            nodes: [
+              {
+                types: [centerModule.TYPE],
+                kinds: ['block'],
+                min: 1,
+                max: 1
+              }
+            ]
+          }
+        },
+        onChange: (change) => {
+          const newData = autoMeta(change.value.document)
+
+          if (newData) {
+            change.setNodeByKey(change.value.document.key, {
+              data: newData
+            })
+            return change
+          }
+        }
+      }
+    ]
+  }
+}

--- a/pages/lorem.js
+++ b/pages/lorem.js
@@ -1,17 +1,15 @@
 import React, { Component } from 'react'
 import { resetKeyGenerator } from 'slate'
 import Frame from '../components/Frame'
-import Editor, {serializer} from '../components/editor/NewsletterEditor'
+import Editor from '../components/editor'
 import withData from '../lib/apollo/withData'
 
-const getInitialState = () => {
+import newsletterSchema from '../components/Templates/Newsletter'
+
+const getInitialState = (editor) => {
   resetKeyGenerator()
   return {
-    state: serializer.deserialize(`---
-a: test
-b: lala
----
-
+    value: editor.serializer.deserialize(`
 Lorem sipsum dolor sit amet, consectetur adipiscing elit. Proin vestibulum dui eget tellus fermentum, eu lobortis libero lacinia. Maecenas commodo lacus dignissim, aliquet risus non, scelerisque dui. Aliquam at massa rutrum ante laoreet pharetra non a nulla. Praesent imperdiet egestas dapibus. Nunc quis lorem vehicula, pharetra nibh quis, dignissim felis. Fusce in justo pharetra, lacinia lorem in, dignissim sem. Phasellus lacinia turpis massa. Etiam eu condimentum diam.
 
 ![](/static/example.jpg)
@@ -23,8 +21,8 @@ Nullam et metus mauris. Quisque scelerisque massa commodo, dapibus tortor in, co
 class Index extends Component {
   constructor (...args) {
     super(...args)
-    this.state = getInitialState()
 
+    this.state = {}
     this.onDocumentChange = (document, change) => {
       try {
         // console.log(serializer.serialize(change.state))
@@ -32,16 +30,23 @@ class Index extends Component {
         // console.error(e)
       }
     }
+    this.editorRef = ref => {
+      this.editor = ref
+    }
   }
-
+  componentDidMount () {
+    this.setState(getInitialState(this.editor))
+  }
   render () {
     const { url } = this.props
     return (
       <Frame url={url} raw>
         <Editor
-          state={this.state.state}
-          onChange={({state}) => {
-            this.setState({state})
+          ref={this.editorRef}
+          schema={newsletterSchema}
+          value={this.state.value}
+          onChange={({value}) => {
+            this.setState({value})
           }}
           onDocumentChange={this.onDocumentChange}
         />

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -25,9 +25,11 @@ import { errorToString } from '../../lib/utils/errors'
 import initLocalStore from '../../lib/utils/localStorage'
 
 import newsletterSchema from '../../components/Templates/Newsletter'
+import neutrumSchema from '../../components/Templates/Neutrum'
 
 const schemas = {
-  newsletter: newsletterSchema
+  newsletter: newsletterSchema,
+  neutrum: neutrumSchema
 }
 
 const fragments = {
@@ -45,6 +47,7 @@ const fragments = {
         content
         meta {
           title
+          template
         }
       }
     }

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -11,7 +11,7 @@ import withAuthorization from '../../components/Auth/withAuthorization'
 
 import Frame from '../../components/Frame'
 import RepoNav from '../../components/Repo/Nav'
-import Editor, { serializer, newDocument } from '../../components/editor/NewsletterEditor'
+import Editor from '../../components/editor'
 
 import EditSidebar from '../../components/EditSidebar'
 import Loader from '../../components/Loader'
@@ -23,6 +23,12 @@ import withT from '../../lib/withT'
 
 import { errorToString } from '../../lib/utils/errors'
 import initLocalStore from '../../lib/utils/localStorage'
+
+import newsletterSchema from '../../components/Templates/Newsletter'
+
+const schemas = {
+  newsletter: newsletterSchema
+}
 
 const fragments = {
   commit: gql`
@@ -116,6 +122,10 @@ class EditorPage extends Component {
     this.commitHandler = this.commitHandler.bind(this)
     this.documentChangeHandler = this.documentChangeHandler.bind(this)
     this.revertHandler = this.revertHandler.bind(this)
+
+    this.editorRef = ref => {
+      this.editor = ref
+    }
 
     this.state = {
       committing: false,
@@ -217,20 +227,42 @@ class EditorPage extends Component {
     if (loading || error) {
       return
     }
-    if (!url.query.commitId && repo && repo.latestCommit) {
+    const repoId = url.query.repoId
+    const commitId = url.query.commitId
+    if (!commitId && repo && repo.latestCommit) {
       Router.replaceRoute('repo/edit', {
-        repoId: url.query.repoId.split('/'),
+        repoId: repoId.split('/'),
         commitId: repo.latestCommit.id
       })
       return
     }
-    const repoId = url.query.repoId
-    const commitId = url.query.commitId
+
+    const { schema } = this.state
+    if (!schema) {
+      const commit = repo && repo.commit
+      let template =
+        (commit && commit.document.meta.template) ||
+        url.query.template
+
+      if (!schemas[template]) {
+        template = Object.keys(schemas)[0]
+      }
+
+      this.setState({
+        schema: schemas[template]
+      }, () => {
+        this.loadState(this.props)
+      })
+      return
+    }
+    if (!this.editor) {
+      return
+    }
 
     const isNew = commitId === 'new'
     let committedEditorState
     if (isNew) {
-      committedEditorState = newDocument(url.query)
+      committedEditorState = this.editor.newDocument(url.query)
     } else {
       const commit = repo.commit
       if (!commit) {
@@ -241,7 +273,7 @@ class EditorPage extends Component {
       }
 
       const json = commit.document.content
-      committedEditorState = serializer.deserialize(json, {
+      committedEditorState = this.editor.serializer.deserialize(json, {
         mdast: true
       })
     }
@@ -266,19 +298,17 @@ class EditorPage extends Component {
       }
     }
 
+    const nextState = {
+      committedRawDocString
+    }
     if (localEditorState) {
       this.beginChanges(repoId)
-      this.setState({
-        editorState: localEditorState,
-        committedRawDocString
-      })
+      nextState.editorState = localEditorState
     } else {
       this.concludeChanges(repoId)
-      this.setState({
-        editorState: committedEditorState,
-        committedRawDocString
-      })
+      nextState.editorState = committedEditorState
     }
+    this.setState(nextState)
   }
 
   changeHandler ({value}) {
@@ -328,7 +358,7 @@ class EditorPage extends Component {
         : commitId,
       message: message,
       document: {
-        content: serializer.serialize(editorState, {
+        content: this.editor.serializer.serialize(editorState, {
           mdast: true
         })
       }
@@ -361,6 +391,7 @@ class EditorPage extends Component {
     const { repoId, commitId } = url.query
     const { loading, repo } = data
     const {
+      schema,
       editorState,
       committing,
       uncommittedChanges,
@@ -370,7 +401,7 @@ class EditorPage extends Component {
 
     const isNew = commitId === 'new'
     const error = data.error || this.state.error
-    const showLoading = committing || loading || (!editorState && !error)
+    const showLoading = committing || loading || (!schema && !error)
 
     return (
       <Frame url={url} raw nav={<RepoNav route='repo/edit' url={url} isNew={isNew} />}>
@@ -378,6 +409,8 @@ class EditorPage extends Component {
           <div>
             <div style={{paddingRight: sidebarWidth}}>
               <Editor
+                ref={this.editorRef}
+                schema={schema}
                 value={editorState}
                 onChange={this.changeHandler}
                 onDocumentChange={this.documentChangeHandler}


### PR DESCRIPTION
Template Support!

<img width="703" alt="screen shot 2017-11-02 at 01 25 45" src="https://user-images.githubusercontent.com/410211/32304063-c86fc3ee-bf6c-11e7-8370-723eb4f0999d.png">

A «Neutrum» template as example.

<img width="1287" alt="screen shot 2017-11-02 at 01 26 31" src="https://user-images.githubusercontent.com/410211/32304091-e5332c00-bf6c-11e7-89f0-f418764f6e29.png">

Noteworthy Changes
- pass schema to editor as prop, initiate everything in constructor
- `newDocument` and `serializer` via the react instance (see `pages/lorem.js` diff)
- listen to `meta.template` for schema choosing