### PR TITLE
Subscribe sidebar to new commits

### DIFF
--- a/components/EditSidebar/CommitHistory.js
+++ b/components/EditSidebar/CommitHistory.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react'
-import { gql, graphql } from 'react-apollo'
 import { Link } from '../../lib/routes'
 import { colors, linkRule, Interaction } from '@project-r/styleguide'
 import { css } from 'glamor'
 import { compose } from 'redux'
 import { swissTime } from '../../lib/utils/format'
-import Loader from '../../components/Loader'
 import withT from '../../lib/withT'
 
 const timeFormat = swissTime.format('%d. %B %Y, %H:%M Uhr')
@@ -33,80 +31,49 @@ const styles = {
   })
 }
 
-const getCommits = gql`
-  query getCommits($repoId: ID!) {
-    repo(id: $repoId) {
-      id
-      commits {
-        id
-        date
-        message
-        author {
-          name
-        }
-      }
-    }
-  }
-`
-
 class CommitHistory extends Component {
   render () {
-    const { data: { loading, error, repo }, commitId, maxItems, t } = this.props
+    const { repoId, commitId, commits, maxItems, t } = this.props
 
-    return (
-      <Loader
-        loading={loading}
-        error={error}
-        render={() => {
-          const numItems = maxItems || 3
-          const repoPath = repo.id.split('/')
-          if (repo.commits.length) {
-            return (
-              <div {...styles.container}>
-                <ul {...styles.commits}>
-                  {repo.commits.slice(0, numItems).map(commit => (
-                    <li key={commit.id} {...styles.commit}>
-                      {commit.id !== commitId ? (
-                        <Link
-                          route='repo/edit'
-                          params={{
-                            repoId: repoPath,
-                            commitId: commit.id
-                          }}
-                        >
-                          <a {...linkRule}>{commit.message}</a>
-                        </Link>
-                      ) : (
-                        <span>{commit.message}</span>
-                      )}
-                      <span {...styles.date}>{commit.author.name}</span>
-                      <span {...styles.date}>
-                        {timeFormat(new Date(commit.date))}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-                <Link route='repo/tree' params={{ repoId: repoPath }}>
-                  <a {...linkRule}>{t('commitHistory/more')}</a>
-                </Link>
-              </div>
-            )
-          } else {
-            return <P>{t('commitHistory/none')}</P>
-          }
-        }}
-      />
-    )
+    const numItems = maxItems || 3
+    const repoPath = repoId.split('/')
+    if (commits.length) {
+      return (
+        <div {...styles.container}>
+          <ul {...styles.commits}>
+            {commits.slice(0, numItems).map(commit => (
+              <li key={commit.id} {...styles.commit}>
+                {commit.id !== commitId ? (
+                  <Link
+                    route='repo/edit'
+                    params={{
+                      repoId: repoPath,
+                      commitId: commit.id
+                    }}
+                  >
+                    <a {...linkRule}>{commit.message}</a>
+                  </Link>
+                ) : (
+                  <span>{commit.message}</span>
+                )}
+                <span {...styles.date}>{commit.author.name}</span>
+                <span {...styles.date}>
+                  {timeFormat(new Date(commit.date))}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <Link route='repo/tree' params={{ repoId: repoPath }}>
+            <a {...linkRule}>{t('commitHistory/more')}</a>
+          </Link>
+        </div>
+      )
+    } else {
+      return <P>{t('commitHistory/none')}</P>
+    }
   }
 }
 
 export default compose(
-  withT,
-  graphql(getCommits, {
-    options: props => ({
-      variables: {
-        repoId: props.repoId
-      }
-    })
-  })
+  withT
 )(CommitHistory)

--- a/components/EditSidebar/index.js
+++ b/components/EditSidebar/index.js
@@ -1,7 +1,16 @@
 import React, { Component } from 'react'
+import { gql, graphql } from 'react-apollo'
 import { css } from 'glamor'
-import { colors } from '@project-r/styleguide'
+import { compose } from 'redux'
+import { A, Button, Label, colors } from '@project-r/styleguide'
 import { HEADER_HEIGHT, ZINDEX_SIDEBAR } from '../Frame/constants'
+import Loader from '../Loader'
+import withT from '../../lib/withT'
+
+import BaseCommit from './BaseCommit'
+import Checklist from './Checklist'
+import CommitHistory from './CommitHistory'
+import UncommittedChanges from './UncommittedChanges'
 
 const styles = {
   container: css({
@@ -15,16 +24,192 @@ const styles = {
     opacity: 1,
     padding: 10,
     zIndex: ZINDEX_SIDEBAR
-  })
+  }),
+  uncommittedChanges: {
+    fontSize: '13px',
+    margin: '0 0 20px'
+  },
+  button: {
+    height: 40,
+    fontSize: '16px'
+  }
 }
 
-export default class EditSidebar extends Component {
+const fragments = {
+  commit: gql`
+    fragment SidebarCommit on Commit {
+      id
+      date
+      message
+      author {
+        name
+      }
+    }
+  `
+}
+
+const getCommits = gql`
+  query getCommits($repoId: ID!) {
+    repo(id: $repoId) {
+      id
+      commits {
+        ...SidebarCommit
+      }
+    }
+  }
+  ${fragments.commit}
+`
+
+const repoSubscription = gql`
+  subscription repoUpdate($repoId: ID!) {
+    repoUpdate(repoId: $repoId) {
+      id
+      commits {
+        ...SidebarCommit
+      }
+    }
+  }
+  ${fragments.commit}
+`
+
+class EditSidebar extends Component {
+  componentDidMount () {
+    this.subscribe()
+  }
+
+  componentDidUpdate () {
+    this.subscribe()
+  }
+
+  subscribe () {
+    if (!this.unsubscribe && this.props.data.repo) {
+      this.unsubscribe = this.props.data.subscribeToMore({
+        document: repoSubscription,
+        variables: {
+          repoId: this.props.repoId
+        },
+        updateQuery: (prev, { subscriptionData }) => {
+          if (!subscriptionData.data) {
+            return prev
+          }
+          const { commits } = subscriptionData.data.repoUpdate
+          if (commits && commits.length) {
+            return {
+              ...prev,
+              repo: {
+                ...prev.repo,
+                commits: [...commits]
+              }
+            }
+          } else {
+            return prev
+          }
+        }
+      })
+    }
+  }
+
+  componentWillUnmount () {
+    this.unsubscribe && this.unsubscribe()
+  }
+
   render () {
-    const { children, width = 200 } = this.props
+    const {
+      t,
+      commit,
+      isNew,
+      uncommittedChanges,
+      commitHandler,
+      revertHandler,
+      warnings,
+      width = 200
+    } = this.props
+    const { loading, error, repo } = this.props.data
+
     return (
-      <div {...styles.container} style={{width}}>
-        {children}
-      </div>
+      <Loader
+        loading={loading}
+        error={error}
+        render={() => (
+          <div {...styles.container} style={{ width }}>
+            {warnings.map((message, i) => (
+              <div key={i} {...css(styles.danger)}>
+                {message}
+              </div>
+            ))}
+            {!!repo && (
+              <BaseCommit
+                repoId={repo.id}
+                commit={commit}
+                commits={repo.commits}
+              />
+            )}
+            <div {...css(styles.uncommittedChanges)}>
+              <div style={{ marginBottom: 10 }}>
+                <Label style={{ fontSize: 12 }}>
+                  <span>
+                    {isNew ? (
+                      t('commit/status/new')
+                    ) : (
+                      t(
+                        uncommittedChanges
+                          ? 'commit/status/uncommitted'
+                          : 'commit/status/committed'
+                      )
+                    )}
+                  </span>
+                </Label>
+              </div>
+              <Button
+                primary
+                block
+                disabled={!uncommittedChanges && !isNew}
+                onClick={commitHandler}
+                style={styles.button}
+              >
+                {t('commit/button')}
+              </Button>
+              {!!uncommittedChanges && (
+                <div style={{ textAlign: 'center', marginTop: 10 }}>
+                  <A href='#' onClick={revertHandler}>
+                    {t('commit/revert')}
+                  </A>
+                </div>
+              )}
+            </div>
+            {!!repo && (
+              <div>
+                <Label>{t('checklist/title')}</Label>
+                <Checklist
+                  disabled={!!uncommittedChanges}
+                  repoId={repo.id}
+                  commitId={commit.id}
+                />
+                <Label>{t('commitHistory/title')}</Label>
+                <CommitHistory
+                  repoId={repo.id}
+                  commitId={commit.id}
+                  commits={repo.commits}
+                />
+              </div>
+            )}
+            <Label>{t('uncommittedChanges/title')}</Label>
+            <UncommittedChanges repoId={repo.id} />
+          </div>
+        )}
+      />
     )
   }
 }
+
+export default compose(
+  withT,
+  graphql(getCommits, {
+    options: props => ({
+      variables: {
+        repoId: props.repoId
+      },
+      fetchPolicy: 'network-only'
+    })
+  })
+)(EditSidebar)

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -2,9 +2,7 @@ import React, { Component } from 'react'
 import { compose } from 'redux'
 import { Router } from '../../lib/routes'
 import { gql, graphql } from 'react-apollo'
-import { css } from 'glamor'
 import { Value, resetKeyGenerator } from 'slate'
-import { A, Button, Label } from '@project-r/styleguide'
 
 import withData from '../../lib/apollo/withData'
 import withAuthorization from '../../components/Auth/withAuthorization'
@@ -15,10 +13,6 @@ import Editor from '../../components/editor'
 
 import EditSidebar from '../../components/EditSidebar'
 import Loader from '../../components/Loader'
-import BaseCommit from '../../components/EditSidebar/BaseCommit'
-import Checklist from '../../components/EditSidebar/Checklist'
-import CommitHistory from '../../components/EditSidebar/CommitHistory'
-import UncommittedChanges from '../../components/EditSidebar/UncommittedChanges'
 import withT from '../../lib/withT'
 
 import { errorToString } from '../../lib/utils/errors'
@@ -95,21 +89,6 @@ const uncommittedChangesMutation = gql`
     uncommittedChanges(repoId: $repoId, action: $action)
   }
 `
-
-const styles = {
-  uncommittedChanges: {
-    fontSize: '13px',
-    margin: '0 0 20px'
-  },
-  danger: {
-    color: 'red',
-    marginBottom: 10
-  },
-  button: {
-    height: 40,
-    fontSize: '16px'
-  }
-}
 
 class EditorPage extends Component {
   constructor (...args) {
@@ -381,7 +360,7 @@ class EditorPage extends Component {
   }
 
   render () {
-    const { url, t, data = {} } = this.props
+    const { url, data = {} } = this.props
     const { repoId, commitId } = url.query
     const { loading, repo } = data
     const {
@@ -410,65 +389,16 @@ class EditorPage extends Component {
                 onDocumentChange={this.documentChangeHandler}
               />
             </div>
-            <EditSidebar width={sidebarWidth}>
-              {warnings.map((message, i) => (
-                <div key={i} {...css(styles.danger)}>
-                  {message}
-                </div>
-              ))}
-              {!!repo &&
-                <BaseCommit repoId={repoId} commitId={commitId} />}
-              <div {...css(styles.uncommittedChanges)}>
-                <div style={{marginBottom: 10}}>
-                  <Label style={{fontSize: 12}}>
-                    <span>
-                      {isNew
-                        ? t('commit/status/new')
-                        : t(uncommittedChanges
-                              ? 'commit/status/uncommitted'
-                              : 'commit/status/committed')
-                      }
-                    </span>
-                  </Label>
-                </div>
-
-                <Button
-                  primary
-                  block
-                  disabled={!uncommittedChanges && !isNew}
-                  onClick={this.commitHandler}
-                  style={styles.button}
-                >
-                  {t('commit/button')}
-                </Button>
-
-                {!!uncommittedChanges && (
-                  <div style={{textAlign: 'center', marginTop: 10}}>
-                    <A href='#' onClick={this.revertHandler}>
-                      {t('commit/revert')}
-                    </A>
-                  </div>
-                )}
-              </div>
-
-              {!!repo && (
-                <div>
-                  <Label>{t('checklist/title')}</Label>
-                  <Checklist
-                    disabled={!!uncommittedChanges}
-                    repoId={repoId}
-                    commitId={commitId}
-                  />
-                  <Label>{t('commitHistory/title')}</Label>
-                  <CommitHistory
-                    repoId={repoId}
-                    commitId={commitId}
-                  />
-                </div>
-              )}
-              <Label>{t('uncommittedChanges/title')}</Label>
-              <UncommittedChanges repoId={repoId} />
-            </EditSidebar>
+            <EditSidebar
+              repoId={repoId}
+              commit={repo.commit || repo.latestCommit}
+              isNew={isNew}
+              uncommittedChanges={uncommittedChanges}
+              warnings={warnings}
+              commitHandler={this.commitHandler}
+              revertHandler={this.revertHandler}
+              width={sidebarWidth}
+            />
           </div>
         )} />
       </Frame>


### PR DESCRIPTION
This solves two current issues with the sidebar:
- If someone else commits something, the commitsBehind count and the commits list don't update
- If you commit yourself, the same happens (only the base commit info gets updated)

Main changes:
- All rendering of sidebar components has moved from pages/repo/edit.js to EditSidebar/index.js
- EditSidebar/index.js is the higher-level component that takes care of loading/subscribing to new commits and piping them through to child components (BaseCommit and CommitHistory)
- The currently loaded commit is piped through from pages/repo/edit.js 

Note that there's another existing issue (before and after this pull request) which still needs fixing:
Switching between versions in the "Versionen" list doesn't load a clicked document version in the editor (but updates the sidebar). Only when clicking back and forth again the document version gets loaded in the editor.


