### PR TITLE
guillemet and longdash buttons through editor-only module specialchars

### DIFF
--- a/components/Templates/Neutrum/index.js
+++ b/components/Templates/Neutrum/index.js
@@ -124,6 +124,9 @@ const schema = {
               }
             }
           ]
+        },
+        {
+          editorModule: 'specialchars'
         }
       ]
     }

--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -22,6 +22,7 @@ import createFigureModule from './modules/figure'
 import createFigureImageModule from './modules/figure/image'
 import createSpecialModule from './modules/special'
 import createMetaModule from './modules/meta'
+import createSpecialCharsModule from './modules/specialchars'
 
 const moduleCreators = {
   document: createDocumentModule,
@@ -38,7 +39,8 @@ const moduleCreators = {
   figure: createFigureModule,
   figureImage: createFigureImageModule,
   special: createSpecialModule,
-  meta: createMetaModule
+  meta: createMetaModule,
+  specialchars: createSpecialCharsModule
 }
 const initModule = rule => {
   const { editorModule, editorOptions = {} } = rule

--- a/components/editor/modules/specialchars/index.js
+++ b/components/editor/modules/specialchars/index.js
@@ -1,0 +1,94 @@
+import { createActionButton, buttonStyles } from '../../utils'
+
+const DoubleGuillemetButton = createActionButton({
+  isDisabled: ({ value }) => {
+    return value.isBlurred || value.isCollapsed
+  },
+  reducer: ({ value, onChange }) => event => {
+    event.preventDefault()
+
+    return onChange(
+    value
+      .change()
+      .wrapText('«', '»')
+  )
+  }
+})(
+({ disabled, visible, ...props }) =>
+  <span
+    {...buttonStyles.insert}
+    {...props}
+    data-disabled={disabled}
+    data-visible={visible}
+    >
+    {'«»'}
+  </span>
+)
+
+const SingleGuillemetButton = createActionButton({
+  isDisabled: ({ value }) => {
+    return value.isBlurred || value.isCollapsed
+  },
+  reducer: ({ value, onChange }) => event => {
+    event.preventDefault()
+    return onChange(
+      value
+        .change()
+        .wrapText('‹', '›')
+    )
+  }
+})(
+({ disabled, visible, ...props }) =>
+  <span
+    {...buttonStyles.insert}
+    {...props}
+    data-disabled={disabled}
+    data-visible={visible}
+    >
+    {'‹›'}
+  </span>
+)
+
+const LongDashButton = createActionButton({
+  isDisabled: ({ value }) => {
+    return value.isBlurred
+  },
+  reducer: ({ value, onChange }) => event => {
+    event.preventDefault()
+
+    return onChange(
+      !value.isCollapsed
+        ? value
+            .change()
+            .wrapText(' – ', ' – ')
+        : value
+            .change()
+            .insertText(' – ')
+  )
+  }
+})(
+({ disabled, visible, ...props }) =>
+  <span
+    {...buttonStyles.insert}
+    {...props}
+    data-disabled={disabled}
+    data-visible={visible}
+    >
+    {'–'}
+  </span>
+)
+
+export default ({ TYPE }) => ({
+  TYPE,
+  helpers: {
+  },
+  changes: {},
+  plugins: [],
+  ui: {
+    insertButtons: [
+      DoubleGuillemetButton,
+      SingleGuillemetButton,
+      LongDashButton
+    ]
+  }
+})


### PR DESCRIPTION
Pretty self-explanatory. Will extend with keyboard shortcuts.
Will probably also have to do a ui cleanup and make all buttons in the sidebar icon-based. This will help with the popover case later on.