### PR TITLE
Regex only on client. Docs.

### DIFF
--- a/components/editor/modules/embed/EmbedLoader.js
+++ b/components/editor/modules/embed/EmbedLoader.js
@@ -40,7 +40,6 @@ export default (query, Component) => (
         ...state
       }), () => {
         const { id, embedType } = node.data.get('queryParams')
-        console.log(id)
         client
           .query({
             query,

--- a/components/editor/modules/embed/EmbedLoader.js
+++ b/components/editor/modules/embed/EmbedLoader.js
@@ -31,27 +31,26 @@ export default (query, Component) => (
 
       if (node.data.has('id')) {
         return
-      } else if (!node.data.has('url')) {
-        return console.warn('No embed URL found.')
+      } else if (!node.data.has('queryParams')) {
+        return console.warn('No embed params found.')
       }
 
       this.setState(state => ({
         loading: true,
         ...state
       }), () => {
-        const url = node.data.get('url')
-
+        const { id, embedType } = node.data.get('queryParams')
+        console.log(id)
         client
           .query({
             query,
-            variables: { url }
+            variables: { id, embedType }
           })
           .then(
             ({ data }) => {
               this.setState({ error: null, loading: false })
               editor.change(t =>
                 t.setNodeByKey(node.key, { data: {
-                  url,
                   ...data.embed
                 } })
               )

--- a/components/editor/modules/embed/embedFromUrlPlugin.js
+++ b/components/editor/modules/embed/embedFromUrlPlugin.js
@@ -1,4 +1,4 @@
-export default ({ matchSource, matchUrl, TYPE }) => ({
+export default ({ matchSource, matchUrl, getQueryParams, TYPE }) => ({
   onKeyDown (event, change) {
     if (event.key !== 'Enter') return
     if (event.shiftKey !== false) return
@@ -22,7 +22,7 @@ export default ({ matchSource, matchUrl, TYPE }) => ({
         kind: 'block',
         type: TYPE,
         data: {
-          url
+          queryParams: getQueryParams(url)
         },
         isVoid: true
       }

--- a/docs/modules/embed.md
+++ b/docs/modules/embed.md
@@ -1,0 +1,73 @@
+# Embed Module
+
+## `embedVideo`
+
+Allows pasting of URL's that point to external resources of:
+* Youtube
+* Vimeo
+
+Example of template rule:
+```
+{
+  matchMdast: matchZone('EMBEDVIDEO'),
+  component: MyVideoComponent,
+  editorModule: 'embedVideo',
+  editorOptions: {
+    lookupType: 'paragraph'
+  }
+}
+```
+
+Notable props:
+* `editorOptions.lookupType` - Slate element that should get searched for Embed URL'.
+
+The render component gets passed a `data` property containing an object
+```
+{
+  "__typename": "YoutubeEmbed",
+  "id": "2lXD0vv-ds8",
+  "createdAt": "2014-10-02T00:00:02.000Z",
+  "userId": "UCj3NRzD4qFJ-zN2iPeF_fMg",
+  "userName": "FlyingLotusVEVO",
+  "thumbnail": "https://i.ytimg.com/vi/2lXD0vv-ds8/sddefault.jpg"
+}
+```
+...where `__typename` can be either `"YoutubeEmbed"` or `"VimeoEmbed"`.
+
+
+## `embedTwitter`
+
+Allows pasting of URL's that point to Tweets aka Twitter "statuses"
+
+Example of template rule:
+```
+{
+  matchMdast: matchZone('EMBEDTWITTER'),
+  component: MyTweetComponent,
+  editorModule: 'embedTwitter',
+  editorOptions: {
+    lookupType: 'paragraph'
+  }
+}
+```
+
+Notable props:
+* `editorOptions.lookupType` - Slate element that should get searched for Embed URL'.
+
+The render component gets passed a `data` property containing an object
+```
+{
+  "__typename": "TwitterEmbed",
+  "id": "931185360972824583",
+  "text": "🗓️ November 16, 2002: @ThierryHenry at his brilliant, brilliant best\n\nWhat. A. Goal. 🙌\n\n#AFCvTHFC 🔴 https://t.co/LQf3AFREYb",
+  "createdAt": "Thu Nov 16 15:41:05 +0000 2017",
+  "userId": "34613288",
+  "userName": "Arsenal FC",
+  "userScreenName": "Arsenal"
+}
+```
+
+## TODO
+* Define the actual keys that are necessary for the frontend components.
+* Find a way to define the lookupType based on a module type rather than plain type.
+* Allow for multiple lookupTypes.


### PR DESCRIPTION
See orbiting/publikator-backend#10.

Most notable change is, that pattern matching happens only on the client now. The graphql accepts an id and a type and responses or throws accordingly. 

And some docs as well. 