### PR TITLE
bump serializer

### DIFF
--- a/components/Templates/Neutrum/index.js
+++ b/components/Templates/Neutrum/index.js
@@ -17,6 +17,10 @@ const Em = ({ children, attributes = {} }) =>
   <em {...attributes}>{ children }</em>
 const Del = ({ children, attributes = {} }) =>
   <del {...attributes}>{ children }</del>
+const Sub = ({ children, attributes = {} }) =>
+  <sub {...attributes}>{ children }</sub>
+const Sup = ({ children, attributes = {} }) =>
+  <sup {...attributes}>{ children }</sup>
 
 const paragraph = {
   matchMdast: matchParagraph,
@@ -57,6 +61,22 @@ const paragraph = {
       }
     },
     {
+      matchMdast: matchType('sub'),
+      component: Sub,
+      editorModule: 'mark',
+      editorOptions: {
+        type: 'sub'
+      }
+    },
+    {
+      matchMdast: matchType('sup'),
+      component: Sup,
+      editorModule: 'mark',
+      editorOptions: {
+        type: 'sup'
+      }
+    },
+    {
       matchMdast: matchType('link'),
       props: node => ({
         data: {
@@ -77,6 +97,7 @@ const paragraph = {
 }
 
 const schema = {
+  repoPrefix: 'dev-',
   rules: [
     {
       matchMdast: matchType('root'),

--- a/components/editor/modules/blockquote/serializer.test.js
+++ b/components/editor/modules/blockquote/serializer.test.js
@@ -1,4 +1,5 @@
 import test from 'tape'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 import createBlockquoteModule from './'
 import createParagraphModule from '../paragraph'
@@ -24,13 +25,13 @@ blockquoteModule.name = 'blockquote'
 const serializer = blockquoteModule.helpers.serializer
 
 test('blockquote serialization', assert => {
-  const value = serializer.deserialize('> A test')
+  const value = serializer.deserialize(parse('> A test'))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, 'BLOCKQUOTE')
   assert.equal(node.text, 'A test')
 
-  assert.equal(serializer.serialize(value).trimRight(), '> A test')
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), '> A test')
   assert.end()
 })

--- a/components/editor/modules/center/index.js
+++ b/components/editor/modules/center/index.js
@@ -38,15 +38,12 @@ export default ({rule, subModules, TYPE}) => {
     ]
   })
 
-  const newDocument = ({title}) => serializer.deserialize(`# ${title}\n\n`)
-
   const Center = rule.component
 
   return {
     TYPE,
     helpers: {
-      serializer,
-      newDocument
+      serializer
     },
     changes: {},
     plugins: [

--- a/components/editor/modules/cover/serializer.test.js
+++ b/components/editor/modules/cover/serializer.test.js
@@ -2,6 +2,7 @@ import test from 'tape'
 import createCoverModule from './'
 import createHeadlineModule from '../headline'
 import createParagraphModule from '../paragraph'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 const TYPE = 'COVER'
 
@@ -46,12 +47,12 @@ test('cover serialization', assert => {
 Lead
 
 <hr /></section>`
-  const value = serializer.deserialize(md)
+  const value = serializer.deserialize(parse(md))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, TYPE)
 
-  assert.equal(serializer.serialize(value).trimRight(), md)
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), md)
   assert.end()
 })

--- a/components/editor/modules/document/index.js
+++ b/components/editor/modules/document/index.js
@@ -1,5 +1,6 @@
 import { Document as SlateDocument } from 'slate'
 import { timeHour } from 'd3-time'
+import { parse } from '@orbiting/remark-preset'
 
 import MarkdownSerializer from 'slate-mdast-serializer'
 import { findOrCreate } from '../../utils/serialization'
@@ -134,7 +135,7 @@ export default ({rule, subModules, TYPE}) => {
     ]
   })
 
-  const newDocument = ({title}) => serializer.deserialize(
+  const newDocument = ({title}) => serializer.deserialize(parse(
 `<section><h6>${coverModule.TYPE}</h6>
 
 # ${title}
@@ -147,7 +148,7 @@ Ladies and Gentlemen,
 
 <hr/></section>
 `
-  )
+  ))
 
   const Container = rule.component
 

--- a/components/editor/modules/document/plain.js
+++ b/components/editor/modules/document/plain.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Document as SlateDocument } from 'slate'
 import { timeHour } from 'd3-time'
 import { timeFormat } from 'd3-time-format'
+import { parse } from '@orbiting/remark-preset'
 
 import { swissTime } from '../../../../lib/utils/format'
 import slugify from '../../../../lib/utils/slug'
@@ -104,7 +105,7 @@ export default ({rule, subModules, TYPE}) => {
     ]
   })
 
-  const newDocument = ({title, template}, me) => serializer.deserialize(
+  const newDocument = ({title, template}, me) => serializer.deserialize(parse(
 `---
 template: ${template}
 ---
@@ -125,7 +126,7 @@ Hurray!
 
 <hr/></section>
 `
-  )
+  ))
 
   const Container = rule.component
 

--- a/components/editor/modules/embed/serializer.test.js
+++ b/components/editor/modules/embed/serializer.test.js
@@ -2,6 +2,7 @@ import test from 'tape'
 import {
   matchZone
 } from 'mdast-react-render/lib/utils'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 import { createEmbedVideoModule, createEmbedTwitterModule } from './'
 import createParagraphModule from '../paragraph'
@@ -57,7 +58,7 @@ test('embedVideo serialization', assert => {
 
 <hr /></section>`
 
-  const value = embedVideoSerializer.deserialize(md)
+  const value = embedVideoSerializer.deserialize(parse(md))
   const embed = value.document.nodes.first()
 
   assert.equal(embed.kind, 'block')
@@ -72,7 +73,7 @@ test('embedVideo serialization', assert => {
     url: 'https://vimeo.com/channels/staffpicks/242527960'
   })
 
-  assert.equal(embedVideoSerializer.serialize(value).trimRight(), md)
+  assert.equal(stringify(embedVideoSerializer.serialize(value)).trimRight(), md)
   assert.end()
 })
 
@@ -94,7 +95,7 @@ test('embedTwitter serialization', assert => {
 
 <hr /></section>`
 
-  const value = embedTwitterSerializer.deserialize(md)
+  const value = embedTwitterSerializer.deserialize(parse(md))
   const embed = value.document.nodes.first()
 
   assert.equal(embed.kind, 'block')
@@ -110,6 +111,6 @@ test('embedTwitter serialization', assert => {
     url: 'https://twitter.com/Arsenal/status/930363029669203969'
   })
 
-  assert.equal(embedTwitterSerializer.serialize(value).trimRight(), md)
+  assert.equal(stringify(embedTwitterSerializer.serialize(value)).trimRight(), md)
   assert.end()
 })

--- a/components/editor/modules/figure/serializer.test.js
+++ b/components/editor/modules/figure/serializer.test.js
@@ -2,6 +2,7 @@ import test from 'tape'
 import createFigureModule from './'
 import createImageModule from './image'
 import createParagraphModule from '../paragraph'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 const TYPE = 'FIGURE'
 
@@ -44,7 +45,7 @@ test('figure serialization', assert => {
 Caption
 
 <hr /></section>`
-  const value = serializer.deserialize(md)
+  const value = serializer.deserialize(parse(md))
   const node = value.document.nodes.first()
 
   const image = node.nodes.first()
@@ -59,6 +60,6 @@ Caption
   assert.equal(caption.type, 'FIGURE_CAPTION')
   assert.equal(caption.text, 'Caption')
 
-  assert.equal(serializer.serialize(value).trimRight(), md)
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), md)
   assert.end()
 })

--- a/components/editor/modules/front/index.js
+++ b/components/editor/modules/front/index.js
@@ -1,4 +1,5 @@
 import MarkdownSerializer from 'slate-mdast-serializer'
+import { parse } from '@orbiting/remark-preset'
 
 export default ({rule, subModules, TYPE}) => {
   const childSerializer = new MarkdownSerializer({
@@ -40,7 +41,7 @@ export default ({rule, subModules, TYPE}) => {
     ]
   })
 
-  const newDocument = ({title, template}) => serializer.deserialize(
+  const newDocument = ({title, template}) => serializer.deserialize(parse(
 `---
 template: ${template}
 ---
@@ -118,8 +119,7 @@ An article by [Christof Moser](), 31 December 2017
 <hr/></section>
 
 `
-
-  )
+  ))
 
   const Container = rule.component
 

--- a/components/editor/modules/headline/serializer.test.js
+++ b/components/editor/modules/headline/serializer.test.js
@@ -1,5 +1,6 @@
 import test from 'tape'
 import createHeadlineModule from './'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 test('h1 serialization', assert => {
   const module = createHeadlineModule({
@@ -14,14 +15,14 @@ test('h1 serialization', assert => {
 
   const serializer = module.helpers.serializer
 
-  const value = serializer.deserialize('# Test')
+  const value = serializer.deserialize(parse('# Test'))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, 'H1')
   assert.equal(node.text, 'Test')
 
-  assert.equal(serializer.serialize(value).trimRight(), '# Test')
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), '# Test')
   assert.end()
 })
 
@@ -38,14 +39,14 @@ test('h2 serialization', assert => {
 
   const serializer = module.helpers.serializer
 
-  const value = serializer.deserialize('## Test')
+  const value = serializer.deserialize(parse('## Test'))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, 'H2')
   assert.equal(node.text, 'Test')
 
-  assert.equal(serializer.serialize(value).trimRight(), '## Test')
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), '## Test')
   assert.end()
 })
 
@@ -62,13 +63,13 @@ test('h3 serialization', assert => {
 
   const serializer = module.helpers.serializer
 
-  const value = serializer.deserialize('### Test')
+  const value = serializer.deserialize(parse('### Test'))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, 'H3')
   assert.equal(node.text, 'Test')
 
-  assert.equal(serializer.serialize(value).trimRight(), '### Test')
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), '### Test')
   assert.end()
 })

--- a/components/editor/modules/link/serializer.test.js
+++ b/components/editor/modules/link/serializer.test.js
@@ -1,4 +1,5 @@
 import test from 'tape'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 import createLinkModule from './'
 import createParagraphModule from '../paragraph'
@@ -24,7 +25,7 @@ paragraphModule.name = 'paragraph'
 const serializer = paragraphModule.helpers.serializer
 
 test('link serialization', assert => {
-  const value = serializer.deserialize('[Test](example.com)')
+  const value = serializer.deserialize(parse('[Test](example.com)'))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
@@ -36,6 +37,6 @@ test('link serialization', assert => {
 
   assert.equal(link.getIn(['data', 'href']), 'example.com')
 
-  assert.equal(serializer.serialize(value).trimRight(), '[Test](example.com)')
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), '[Test](example.com)')
   assert.end()
 })

--- a/components/editor/modules/mark/index.js
+++ b/components/editor/modules/mark/index.js
@@ -5,12 +5,17 @@ import { matchMark, createMarkButton, buttonStyles } from '../../utils'
 import BoldIcon from 'react-icons/lib/fa/bold'
 import ItalicIcon from 'react-icons/lib/fa/italic'
 import StrikethroughIcon from 'react-icons/lib/fa/strikethrough'
+import SubIcon from 'react-icons/lib/fa/subscript'
+import SupIcon from 'react-icons/lib/fa/superscript'
+
 import MarkdownSerializer from 'slate-mdast-serializer'
 
 const icons = {
   strong: BoldIcon,
   emphasis: ItalicIcon,
-  delete: StrikethroughIcon
+  delete: StrikethroughIcon,
+  sub: SubIcon,
+  sup: SupIcon
 }
 
 export default ({rule, subModules, TYPE}) => {

--- a/components/editor/modules/mark/serializer.test.js
+++ b/components/editor/modules/mark/serializer.test.js
@@ -33,11 +33,31 @@ const deleteModule = createMarkModule({
   },
   subModules: []
 })
+const subModule = createMarkModule({
+  TYPE: 'SUB',
+  rule: {
+    matchMdast: node => node.type === 'sub',
+    editorOptions: {
+      type: 'sub'
+    }
+  },
+  subModules: []
+})
+const supModule = createMarkModule({
+  TYPE: 'SUP',
+  rule: {
+    matchMdast: node => node.type === 'sup',
+    editorOptions: {
+      type: 'sup'
+    }
+  },
+  subModules: []
+})
 
 const paragraphModule = createParagraphModule({
   TYPE: 'P',
   rule: {},
-  subModules: [boldModule, emphasisModule, deleteModule]
+  subModules: [boldModule, emphasisModule, deleteModule, subModule, supModule]
 })
 paragraphModule.name = 'paragraph'
 
@@ -94,5 +114,13 @@ test('mark serialization', assert => {
   assert.equal(youMarks.first().type, 'STRONG')
 
   assert.equal(stringify(serializer.serialize(value)).trimRight(), md)
+  assert.end()
+})
+
+test('mark subsup serialization', assert => {
+  const md = 'CO<sub>2eq</sub> 40 µg/m<sup>3</sup>\n'
+  const value = serializer.deserialize(parse(md))
+
+  assert.equal(stringify(serializer.serialize(value)), md)
   assert.end()
 })

--- a/components/editor/modules/mark/serializer.test.js
+++ b/components/editor/modules/mark/serializer.test.js
@@ -1,6 +1,7 @@
 import test from 'tape'
 import createMarkModule from './'
 import createParagraphModule from '../paragraph'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 const boldModule = createMarkModule({
   TYPE: 'STRONG',
@@ -44,7 +45,7 @@ const serializer = paragraphModule.helpers.serializer
 
 test('mark serialization', assert => {
   const md = `_Hello_ ~~World~~**You**`
-  const value = serializer.deserialize(md)
+  const value = serializer.deserialize(parse(md))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
@@ -92,6 +93,6 @@ test('mark serialization', assert => {
   assert.equal(youMarks.size, 1)
   assert.equal(youMarks.first().type, 'STRONG')
 
-  assert.equal(serializer.serialize(value).trimRight(), md)
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), md)
   assert.end()
 })

--- a/components/editor/modules/paragraph/serializer.test.js
+++ b/components/editor/modules/paragraph/serializer.test.js
@@ -1,5 +1,6 @@
 import test from 'tape'
 import createParagraphModule from './'
+import { parse, stringify } from '@orbiting/remark-preset'
 
 const paragraphModule = createParagraphModule({
   TYPE: 'P',
@@ -10,13 +11,13 @@ const paragraphModule = createParagraphModule({
 const serializer = paragraphModule.helpers.serializer
 
 test('paragraph serialization', assert => {
-  const value = serializer.deserialize('Test')
+  const value = serializer.deserialize(parse('Test'))
   const node = value.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, 'P')
   assert.equal(node.text, 'Test')
 
-  assert.equal(serializer.serialize(value).trimRight(), 'Test')
+  assert.equal(stringify(serializer.serialize(value)).trimRight(), 'Test')
   assert.end()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,20 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@orbiting/remark-preset": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@orbiting/remark-preset/-/remark-preset-1.2.0.tgz",
+      "integrity": "sha512-6+b7rvC3P2upqkIKG/vz8Ip4NectBArPUtm5Cno/wyxV0LNi7EIaibgxD8zWnyhxwAeYkAuG6CVY/O7IvORZ6Q==",
+      "requires": {
+        "js-yaml": "3.10.0",
+        "parse-entities": "1.1.1",
+        "remark-frontmatter": "1.2.0",
+        "remark-parse": "4.0.0",
+        "remark-stringify": "4.0.0",
+        "stringify-entities": "1.3.1",
+        "unified": "6.1.6"
+      }
+    },
     "@project-r/styleguide": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.15.0.tgz",
@@ -8597,16 +8611,11 @@
       "integrity": "sha512-ZMVkyKeZyVi3I+zjP7V4AyhP/oiO8hi2rlYV47gDT3S1GNFsYiq8PLBX8TSML+1gGrSrUowOIbXFwG++9ljemw=="
     },
     "slate-mdast-serializer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slate-mdast-serializer/-/slate-mdast-serializer-1.0.0.tgz",
-      "integrity": "sha512-WZ6kQ8pG6VaRYD9ZJ2sCbFeAL+Ov/GJUvZH4WucZJAS7B+b9+ot/Dwk4haGktvXT2O6sX1juQtZJEhIZSLPT4A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slate-mdast-serializer/-/slate-mdast-serializer-2.0.0.tgz",
+      "integrity": "sha512-mTMHq9d1UgFeXbi/7Y4e/Gd7HbkMjr/SI6paqeROVqj9TtkSoPYcuUbLJD7WA0+DD8AgRzWZnhiTxQ9rnTEgIg==",
       "requires": {
-        "js-yaml": "3.10.0",
-        "lodash.isequal": "4.5.0",
-        "remark-frontmatter": "1.2.0",
-        "remark-parse": "4.0.0",
-        "remark-stringify": "4.0.0",
-        "unified": "6.1.6"
+        "lodash.isequal": "4.5.0"
       }
     },
     "slate-plain-serializer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@orbiting/remark-preset": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@orbiting/remark-preset/-/remark-preset-1.2.0.tgz",
-      "integrity": "sha512-6+b7rvC3P2upqkIKG/vz8Ip4NectBArPUtm5Cno/wyxV0LNi7EIaibgxD8zWnyhxwAeYkAuG6CVY/O7IvORZ6Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@orbiting/remark-preset/-/remark-preset-1.2.1.tgz",
+      "integrity": "sha512-E40A4GdRpBHqIWAuZPYUu4h1WKkBRxSu9N6mnhTBucP/C9N1D7cfMS87l9S1bAvBdMIbctXfdCy/uSMtqB03iQ==",
       "requires": {
         "js-yaml": "3.10.0",
         "parse-entities": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "tape": "^4.8.0"
   },
   "dependencies": {
-    "@orbiting/remark-preset": "^1.2.0",
+    "@orbiting/remark-preset": "^1.2.1",
     "@project-r/styleguide": "^5.15.0",
     "@project-r/template-newsletter": "^1.4.3",
     "d3-array": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "tape": "^4.8.0"
   },
   "dependencies": {
+    "@orbiting/remark-preset": "^1.2.0",
     "@project-r/styleguide": "^5.15.0",
     "@project-r/template-newsletter": "^1.4.3",
     "d3-array": "^1.2.0",
@@ -91,7 +92,7 @@
     "remark-parse": "^4.0.0",
     "remark-stringify": "^4.0.0",
     "slate": "^0.30.6",
-    "slate-mdast-serializer": "^1.0.0",
+    "slate-mdast-serializer": "^2.0.0",
     "slate-react": "^0.10.10",
     "subscriptions-transport-ws": "^0.8.2",
     "unified": "^6.1.5"

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -261,9 +261,7 @@ class EditorPage extends Component {
       }
 
       const json = commit.document.content
-      committedEditorState = this.editor.serializer.deserialize(json, {
-        mdast: true
-      })
+      committedEditorState = this.editor.serializer.deserialize(json)
     }
     const committedRawDocString = JSON.stringify(
       committedEditorState.document.toJSON()
@@ -346,9 +344,7 @@ class EditorPage extends Component {
         : commitId,
       message: message,
       document: {
-        content: this.editor.serializer.serialize(editorState, {
-          mdast: true
-        })
+        content: this.editor.serializer.serialize(editorState)
       }
     })
       .then(({data}) => {


### PR DESCRIPTION
The new serializer no longer deals with markdown—only mdast.

Parse and stringify is now handled by [`@orbiting/remark-preset`](https://github.com/orbiting/mdast/tree/master/packages/remark-preset#readme).

It also ships with new features: `sup`, `sup` and [`span`](https://github.com/orbiting/mdast/tree/master/packages/remark-preset#span-type) (with flat data support). I've added support for `sub` and `sup` in the mark module.

<img width="772" alt="screen shot 2017-12-10 at 22 16 24" src="https://user-images.githubusercontent.com/410211/33809485-cdfc0f12-ddf7-11e7-994e-cd83c93898f5.png">