### PR TITLE
revert all insert buttons to plain components

### DIFF
--- a/components/editor/modules/figure/ui.js
+++ b/components/editor/modules/figure/ui.js
@@ -5,7 +5,6 @@ import { Radio, Label } from '@project-r/styleguide'
 
 import {
   createPropertyForm,
-  createActionButton,
   buttonStyles
 } from '../../utils'
 import injectBlock from '../../utils/injectBlock'
@@ -145,37 +144,34 @@ export default ({TYPE, FIGURE_IMAGE, FIGURE_CAPTION, newBlock, editorOptions}) =
     </div>
   })
 
-  const FigureButton = createActionButton({
-    isDisabled: ({ value }) => {
-      return value.isBlurred
-    },
-    reducer: ({ value, onChange }) => event => {
-      event.preventDefault()
+  const figureButtonClickHandler = (value, onChange) => event => {
+    event.preventDefault()
+    return onChange(
+      value
+        .change()
+        .call(
+          injectBlock,
+          newBlock()
+        )
+    )
+  }
 
-      return onChange(
-        value
-          .change()
-          .call(
-            injectBlock,
-            newBlock()
-          )
-      )
-    }
-  })(
-    ({ disabled, visible, ...props }) =>
+  const FigureButton = ({ value, onChange }) => {
+    // const disabled = value.isBlurred
+    return (
       <span
         {...buttonStyles.insert}
-        {...props}
-        data-disabled={disabled}
-        data-visible={visible}
+        data-disabled={false}
+        data-visible
+        onMouseDown={figureButtonClickHandler(value, onChange)}
         >
         {insertButtonText}
       </span>
-
-  )
+    )
+  }
 
   return {
     forms: [FigureForm],
-    insertButtons: [insertButtonText && FigureButton].filter(Boolean)
+    insertButtons: [insertButtonText && FigureButton]
   }
 }

--- a/components/editor/modules/figure/ui.js
+++ b/components/editor/modules/figure/ui.js
@@ -157,11 +157,11 @@ export default ({TYPE, FIGURE_IMAGE, FIGURE_CAPTION, newBlock, editorOptions}) =
   }
 
   const FigureButton = ({ value, onChange }) => {
-    // const disabled = value.isBlurred
+    const disabled = value.isBlurred
     return (
       <span
         {...buttonStyles.insert}
-        data-disabled={false}
+        data-disabled={disabled}
         data-visible
         onMouseDown={figureButtonClickHandler(value, onChange)}
         >

--- a/components/editor/modules/infobox/ui.js
+++ b/components/editor/modules/infobox/ui.js
@@ -6,7 +6,6 @@ import { Radio, Label } from '@project-r/styleguide'
 
 import {
   createPropertyForm,
-  createActionButton,
   buttonStyles
 } from '../../utils'
 import MetaForm from '../../utils/MetaForm'
@@ -130,38 +129,39 @@ export default ({TYPE, subModules, editorOptions = {}, figureModule}) => {
     </div>
   })
 
+  const infoBoxButtonClickHandler = (value, onChange) => event => {
+    event.preventDefault()
+
+    return onChange(
+      value
+        .change()
+        .call(
+          injectBlock,
+          Block.create({
+            type: TYPE,
+            nodes: subModules.map(module => Block.create(module.TYPE))
+          })
+        )
+    )
+  }
+
+  const InfoboxButton = ({ value, onChange }) => {
+    const disabled = value.isBlurred
+    return (
+      <span
+        {...buttonStyles.insert}
+        data-disabled={disabled}
+        data-visible
+        onMouseDown={infoBoxButtonClickHandler(value, onChange)}
+        >
+        {insertButtonText}
+      </span>
+    )
+  }
+
   return {
     insertButtons: [
-      insertButtonText && createActionButton({
-        isDisabled: ({ value }) => {
-          return value.isBlurred
-        },
-        reducer: ({ value, onChange }) => event => {
-          event.preventDefault()
-
-          return onChange(
-            value
-              .change()
-              .call(
-                injectBlock,
-                Block.create({
-                  type: TYPE,
-                  nodes: subModules.map(module => Block.create(module.TYPE))
-                })
-              )
-          )
-        }
-      })(
-        ({ disabled, visible, ...props }) =>
-          <span
-            {...buttonStyles.insert}
-            {...props}
-            data-disabled={disabled}
-            data-visible={visible}
-            >
-            {insertButtonText}
-          </span>
-      )
+      insertButtonText && InfoboxButton
     ],
     forms: [Form]
   }

--- a/components/editor/modules/quote/ui.js
+++ b/components/editor/modules/quote/ui.js
@@ -5,7 +5,6 @@ import { Radio, Label } from '@project-r/styleguide'
 
 import {
   createPropertyForm,
-  createActionButton,
   buttonStyles
 } from '../../utils'
 
@@ -77,38 +76,39 @@ export default ({TYPE, subModules, editorOptions = {}, figureModule}) => {
     </div>
   })
 
+  const quoteButtonClickHandler = (value, onChange) => event => {
+    event.preventDefault()
+
+    return onChange(
+      value
+        .change()
+        .call(
+          injectBlock,
+          Block.create({
+            type: TYPE,
+            nodes: subModules.map(module => Block.create(module.TYPE))
+          })
+        )
+    )
+  }
+
+  const QuoteButton = ({ value, onChange }) => {
+    const disabled = value.isBlurred
+    return (
+      <span
+        {...buttonStyles.insert}
+        data-disabled={disabled}
+        data-visible
+        onMouseDown={quoteButtonClickHandler(value, onChange)}
+        >
+        {insertButtonText}
+      </span>
+    )
+  }
+
   return {
     insertButtons: [
-      insertButtonText && createActionButton({
-        isDisabled: ({ value }) => {
-          return value.isBlurred
-        },
-        reducer: ({ value, onChange }) => event => {
-          event.preventDefault()
-
-          return onChange(
-            value
-              .change()
-              .call(
-                injectBlock,
-                Block.create({
-                  type: TYPE,
-                  nodes: subModules.map(module => Block.create(module.TYPE))
-                })
-              )
-          )
-        }
-      })(
-        ({ disabled, visible, ...props }) =>
-          <span
-            {...buttonStyles.insert}
-            {...props}
-            data-disabled={disabled}
-            data-visible={visible}
-            >
-            {insertButtonText}
-          </span>
-      )
+      insertButtonText && QuoteButton
     ],
     forms: [Form]
   }

--- a/components/editor/modules/specialchars/index.js
+++ b/components/editor/modules/specialchars/index.js
@@ -1,82 +1,72 @@
-import { createActionButton, buttonStyles } from '../../utils'
+import { buttonStyles } from '../../utils'
 
-const DoubleGuillemetButton = createActionButton({
-  isDisabled: ({ value }) => {
-    return value.isBlurred || value.isCollapsed
-  },
-  reducer: ({ value, onChange }) => event => {
-    event.preventDefault()
-
-    return onChange(
+const doubleGuillemetClickHandler = (value, onChange) => event => {
+  event.preventDefault()
+  return onChange(
     value
       .change()
       .wrapText('«', '»')
   )
-  }
-})(
-({ disabled, visible, ...props }) =>
-  <span
+}
+
+const DoubleGuillemetButton = ({ value, onChange }) => {
+  const disabled = value.isBlurred || value.isCollapsed
+  return <span
     {...buttonStyles.insert}
-    {...props}
     data-disabled={disabled}
-    data-visible={visible}
-    >
+    data-visible
+    onMouseDown={doubleGuillemetClickHandler(value, onChange)}
+      >
     {'«»'}
   </span>
-)
+}
 
-const SingleGuillemetButton = createActionButton({
-  isDisabled: ({ value }) => {
-    return value.isBlurred || value.isCollapsed
-  },
-  reducer: ({ value, onChange }) => event => {
-    event.preventDefault()
-    return onChange(
-      value
-        .change()
-        .wrapText('‹', '›')
-    )
-  }
-})(
-({ disabled, visible, ...props }) =>
-  <span
+const singleGuillemetClickHandler = (value, onChange) => event => {
+  event.preventDefault()
+  return onChange(
+    value
+      .change()
+      .wrapText('‹', '›')
+  )
+}
+
+const SingleGuillemetButton = ({ value, onChange }) => {
+  const disabled = value.isBlurred || value.isCollapsed
+  return <span
     {...buttonStyles.insert}
-    {...props}
     data-disabled={disabled}
-    data-visible={visible}
-    >
+    data-visible
+    onMouseDown={singleGuillemetClickHandler(value, onChange)}
+      >
     {'‹›'}
   </span>
-)
+}
 
-const LongDashButton = createActionButton({
-  isDisabled: ({ value }) => {
-    return value.isBlurred
-  },
-  reducer: ({ value, onChange }) => event => {
-    event.preventDefault()
+const longDashClickHandler = (value, onChange) => event => {
+  event.preventDefault()
 
-    return onChange(
-      !value.isCollapsed
-        ? value
-            .change()
-            .wrapText(' – ', ' – ')
-        : value
-            .change()
-            .insertText(' – ')
-  )
-  }
-})(
-({ disabled, visible, ...props }) =>
-  <span
+  return onChange(
+    !value.isCollapsed
+      ? value
+          .change()
+          .wrapText(' – ', ' – ')
+      : value
+          .change()
+          .insertText(' – ')
+        )
+}
+
+const LongDashButton = ({ value, onChange }) => {
+  const disabled = value.isBlurred || value.isCollapsed
+  return <span
     {...buttonStyles.insert}
-    {...props}
     data-disabled={disabled}
-    data-visible={visible}
-    >
-    {'–'}
+    data-visible
+    onMouseDown={longDashClickHandler(value, onChange)}
+      >
+    {'‹›'}
   </span>
-)
+}
 
 export default ({ TYPE }) => ({
   TYPE,

--- a/components/editor/modules/specialchars/index.js
+++ b/components/editor/modules/specialchars/index.js
@@ -64,7 +64,7 @@ const LongDashButton = ({ value, onChange }) => {
     data-visible
     onMouseDown={longDashClickHandler(value, onChange)}
       >
-    {'‹›'}
+    {'–'}
   </span>
 }
 

--- a/components/editor/modules/teaser/ui.js
+++ b/components/editor/modules/teaser/ui.js
@@ -2,7 +2,6 @@ import { colors, Field, Dropdown, Checkbox, Label, P } from '@project-r/stylegui
 import React from 'react'
 import { css } from 'glamor'
 import {
-  createActionButton,
   buttonStyles,
   createPropertyForm,
   matchBlock
@@ -119,19 +118,15 @@ const styles = {
   )
 }
 
-export const TeaserButton = options => createActionButton({
-  reducer: ({ value, onChange }) => event => {
-  }
-})(
-  ({ disabled, children, visible, ...props }) => {
+export const TeaserButton = options => {
+  return ({ children }) => {
     const Component = createInsertDragSource(
       ({ connectDragSource }) =>
       connectDragSource(
         <span
           {...buttonStyles.insert}
-          {...props}
-          data-disabled={disabled}
-          data-visible={visible}
+          data-disabled={false}
+          data-visible
           >
           {options.rule.editorOptions.insertButton}
         </span>
@@ -141,7 +136,7 @@ export const TeaserButton = options => createActionButton({
       <Component getNewItem={getNewItem(options)} />
     )
   }
-)
+}
 
 const Form = ({ node, onChange, options }) => {
   return <SidebarForm>


### PR DESCRIPTION
Remove usage of `createActionButton` in all modules that are used in templates "front" and "article"