### PR TITLE
no auto publishDate

### DIFF
--- a/components/Publication/PublishForm.js
+++ b/components/Publication/PublishForm.js
@@ -155,7 +155,7 @@ class PublishForm extends Component {
           const schema = getSchema(meta.template)
 
           const errors = [
-            !meta.slug && t('publish/validation/slug/empty'),
+            (meta.template !== 'front' && !meta.slug) && t('publish/validation/slug/empty'),
             (updateMailchimp && !meta.emailSubject) && t('publish/validation/emailSubject/empty')
           ].filter(Boolean)
           const hasErrors = errors.length > 0

--- a/components/Publication/PublishForm.js
+++ b/components/Publication/PublishForm.js
@@ -156,7 +156,6 @@ class PublishForm extends Component {
 
           const errors = [
             !meta.slug && t('publish/validation/slug/empty'),
-            !meta.publishDate && t('publish/validation/publishDate/empty'),
             (updateMailchimp && !meta.emailSubject) && t('publish/validation/emailSubject/empty')
           ].filter(Boolean)
           const hasErrors = errors.length > 0

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -318,17 +318,17 @@ class RepoList extends Component {
                       )} />
                       {' '}
                       {repo.latestPublications
-                        .filter(publication => publication.prepublication)
-                        .map(publication => (
-                          <a key={publication.name} href={`${FRONTEND_BASE_URL}/${publication.commit.document.meta.slug}`}>
+                        .filter(publication => publication.document && publication.prepublication)
+                        .map(({name, document: {meta: {path, slug}}}) => (
+                          <a key={name} href={`${FRONTEND_BASE_URL}${path || '/' + slug}`}>
                             <LockIcon color={colors.primary} />
                           </a>
                         ))}
                       {' '}
                       {repo.latestPublications
-                        .filter(publication => !publication.prepublication && publication.live)
-                        .map(publication => (
-                          <a key={publication.name} href={`${FRONTEND_BASE_URL}/${publication.commit.document.meta.slug}`}>
+                        .filter(publication => publication.document && !publication.prepublication && publication.live)
+                        .map(({name, document: {meta: {path, slug}}}) => (
+                          <a key={name} href={`${FRONTEND_BASE_URL}${path || '/' + slug}`}>
                             <PublicIcon color={colors.primary} />
                           </a>
                         ))}
@@ -383,12 +383,10 @@ query repos($after: String, $search: String) {
         prepublication
         live
         scheduledAt
-        commit {
-          id
-          document {
-            meta {
-              slug
-            }
+        document {
+          meta {
+            path
+            slug
           }
         }
       }

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -103,7 +103,7 @@ const orderFields = [
   {
     field: 'published',
     label: 'Publikationsdatum',
-    accessor: repo => new Date(repo.latestCommit.document.meta.publishDate)
+    accessor: repo => new Date(repo.meta.publishDate)
   },
   {
     field: 'creationDeadline',
@@ -268,7 +268,7 @@ class RepoList extends Component {
               .map(({repo, phase}) => {
                 const {
                   id,
-                  meta: {creationDeadline, productionDeadline, briefingUrl},
+                  meta: {creationDeadline, productionDeadline, publishDate, briefingUrl},
                   latestCommit: {date, document: {meta}}
                 } = repo
 
@@ -288,7 +288,13 @@ class RepoList extends Component {
                       () => ', '
                     )}</Td>
                     <TdNum>{displayDateTime(date)}</TdNum>
-                    <TdNum>{displayDateTime(meta.publishDate)}</TdNum>
+                    <TdNum>
+                      <EditMetaDate
+                        value={publishDate}
+                        onChange={(value) => editRepoMeta(
+                          {repoId: id, publishDate: value}
+                        )} />
+                    </TdNum>
                     <TdNum>
                       <EditMetaDate
                         value={creationDeadline}
@@ -353,6 +359,7 @@ query repos($after: String, $search: String) {
       meta {
         creationDeadline
         productionDeadline
+        publishDate
         briefingUrl
       }
       latestCommit {
@@ -363,7 +370,6 @@ query repos($after: String, $search: String) {
           meta {
             template
             title
-            publishDate
             credits
           }
         }
@@ -392,12 +398,13 @@ query repos($after: String, $search: String) {
 `
 
 const mutation = gql`
-mutation editRepoMeta($repoId: ID!, $creationDeadline: DateTime, $productionDeadline: DateTime, $briefingUrl: String) {
-  editRepoMeta(repoId: $repoId, creationDeadline: $creationDeadline, productionDeadline: $productionDeadline, briefingUrl: $briefingUrl) {
+mutation editRepoMeta($repoId: ID!, $creationDeadline: DateTime, $productionDeadline: DateTime, $publishDate: DateTime, $briefingUrl: String) {
+  editRepoMeta(repoId: $repoId, creationDeadline: $creationDeadline, productionDeadline: $productionDeadline, publishDate: $publishDate, briefingUrl: $briefingUrl) {
     id
     meta {
       creationDeadline
       productionDeadline
+      publishDate
       briefingUrl
     }
   }

--- a/components/editor/modules/document/index.js
+++ b/components/editor/modules/document/index.js
@@ -1,5 +1,4 @@
 import { Document as SlateDocument } from 'slate'
-import { timeHour } from 'd3-time'
 import { parse } from '@orbiting/remark-preset'
 
 import MarkdownSerializer from 'slate-mdast-serializer'
@@ -39,7 +38,6 @@ export default ({rule, subModules, TYPE}) => {
       .set('title', title ? title.text : '')
       .set('description', lead ? lead.text : '')
       .set('image', cover.data.get('src'))
-      .set('publishDate', timeHour.ceil(new Date()).toISOString())
 
     return data.equals(newData)
       ? null

--- a/components/editor/modules/document/index.js
+++ b/components/editor/modules/document/index.js
@@ -3,6 +3,7 @@ import { parse } from '@orbiting/remark-preset'
 
 import MarkdownSerializer from 'slate-mdast-serializer'
 import { findOrCreate } from '../../utils/serialization'
+import slugify from '../../../../lib/utils/slug'
 
 export default ({rule, subModules, TYPE}) => {
   const coverModule = subModules.find(m => m.name === 'cover')
@@ -36,6 +37,7 @@ export default ({rule, subModules, TYPE}) => {
       .set('auto', true)
       .set('feed', true)
       .set('title', title ? title.text : '')
+      .set('slug', title ? slugify(title.text) : '')
       .set('description', lead ? lead.text : '')
       .set('image', cover.data.get('src'))
 

--- a/components/editor/modules/document/plain.js
+++ b/components/editor/modules/document/plain.js
@@ -40,7 +40,6 @@ export default ({rule, subModules, TYPE}) => {
     let newData = data
       .set('auto', true)
       .set('feed', true)
-      .set('publishDate', nextHour.toISOString())
 
     const title = titleModule && documentNode.nodes
       .find(n => n.type === titleModule.TYPE && n.kind === 'block')

--- a/components/editor/modules/document/plain.js
+++ b/components/editor/modules/document/plain.js
@@ -1,14 +1,11 @@
 import React from 'react'
 import { Document as SlateDocument } from 'slate'
-import { timeHour } from 'd3-time'
-import { timeFormat } from 'd3-time-format'
 import { parse } from '@orbiting/remark-preset'
 
 import { swissTime } from '../../../../lib/utils/format'
 import slugify from '../../../../lib/utils/slug'
 import MarkdownSerializer from 'slate-mdast-serializer'
 
-const slugDateFormat = timeFormat('%Y/%m/%d')
 const pubDateFormat = swissTime.format('%-d. %B %Y')
 
 export default ({rule, subModules, TYPE}) => {
@@ -36,7 +33,6 @@ export default ({rule, subModules, TYPE}) => {
       return null
     }
 
-    const nextHour = timeHour.ceil(new Date())
     let newData = data
       .set('auto', true)
       .set('feed', true)
@@ -51,16 +47,7 @@ export default ({rule, subModules, TYPE}) => {
       newData = newData
         .set('title', headlineText)
         .set('description', lead ? lead.text : '')
-        .set('slug', [
-          slugDateFormat(nextHour),
-          slugify(headlineText)
-        ].join('/'))
-    } else {
-      newData = newData
-        .set('slug', [
-          slugDateFormat(nextHour),
-          ''
-        ].join('/'))
+        .set('slug', slugify(headlineText))
     }
 
     return data.equals(newData)

--- a/components/editor/utils/MetaForm.js
+++ b/components/editor/utils/MetaForm.js
@@ -124,12 +124,11 @@ class Form extends Component {
                 ? value
                 : (
                   parseDate(value) ||
-                  (value && new Date(value)) ||
-                  new Date()
+                  (value && new Date(value))
                 )
               formattedValue = this.state[key] !== undefined
                 ? this.state[key].formatted
-                : formatDate(dateValue)
+                : dateValue ? formatDate(dateValue) : null
 
               onChange = (_, inputValue) => {
                 const parsedValue = parseDate(inputValue) || ''

--- a/components/editor/utils/MetaForm.js
+++ b/components/editor/utils/MetaForm.js
@@ -128,7 +128,7 @@ class Form extends Component {
                 )
               formattedValue = this.state[key] !== undefined
                 ? this.state[key].formatted
-                : dateValue ? formatDate(dateValue) : null
+                : dateValue ? formatDate(dateValue) : ''
 
               onChange = (_, inputValue) => {
                 const parsedValue = parseDate(inputValue) || ''


### PR DESCRIPTION
The argument from the production team is the following: now it sets a publishDate automatically to today. This is almost ever not true and the production team manually opens all documents and removes it until it's defined when the article is going to be published. This is even more severe because the date is shown in the overview table as "planned publish date".

@tpreusse please check if I missed other places and if I didn't notice unwanted consequences of the code changes.

edit:
Has to be merged together with:
https://github.com/orbiting/republik-frontend/pull/38
https://github.com/orbiting/backend-modules/pull/9
https://github.com/orbiting/publikator-backend/pull/26