### PR TITLE
Repos in meta

### DIFF
--- a/components/editor/modules/link/ui.js
+++ b/components/editor/modules/link/ui.js
@@ -46,13 +46,6 @@ const SearchUserForm = withT(class extends Component {
     this.filterChangeHandler = this.filterChangeHandler.bind(this)
     this.changeHandler = this.changeHandler.bind(this)
   }
-  componentDidMount () {
-    this._isMounted = true
-  }
-
-  componentWillUnmount () {
-    this._isMounted = false
-  }
 
   filterChangeHandler (value) {
     this.setState(

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -101,7 +101,7 @@ const MetaData = ({value, editor, additionalFields = [], customFields = [], teas
               return <RepoSearch key={customField.key}
                 label={label}
                 value={value}
-                onChange={item => onChange(undefined, item.value.id)}
+                onChange={item => onChange(undefined, `https://github.com/${item.value.id}`)}
                 />
             }
             return <Field key={customField.key}

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -6,6 +6,7 @@ import { Interaction, Dropdown, Field, Label, colors } from '@project-r/stylegui
 
 import withT from '../../../../lib/withT'
 import MetaForm from '../../utils/MetaForm'
+import RepoSearch from '../../utils/RepoSearch'
 import FBPreview from './FBPreview'
 import TwitterPreview from './TwitterPreview'
 import UIForm from '../../UIForm'
@@ -75,7 +76,6 @@ const MetaData = ({value, editor, additionalFields = [], customFields = [], teas
         })
     })
   }
-
   return (
     <div {...styles.container}>
       <div {...styles.center}>
@@ -96,6 +96,13 @@ const MetaData = ({value, editor, additionalFields = [], customFields = [], teas
                 label={label}
                 value={value}
                 onChange={item => onChange(undefined, item.value)} />
+            }
+            if (customField.ref === 'repo') {
+              return <RepoSearch key={customField.key}
+                label={label}
+                value={value}
+                onChange={item => onChange(undefined, item.value)}
+                />
             }
             return <Field key={customField.key}
               black

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -101,7 +101,7 @@ const MetaData = ({value, editor, additionalFields = [], customFields = [], teas
               return <RepoSearch key={customField.key}
                 label={label}
                 value={value}
-                onChange={item => onChange(undefined, item.value)}
+                onChange={item => onChange(undefined, item.value.id)}
                 />
             }
             return <Field key={customField.key}

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -1,0 +1,139 @@
+import React, { Component } from 'react'
+import { gql, graphql } from 'react-apollo'
+import { Autocomplete } from '@project-r/styleguide'
+import debounce from 'lodash.debounce'
+
+import { GITHUB_ORG, REPO_PREFIX } from '../../../lib/settings'
+
+const repoQuery = gql`
+query repos($after: String, $search: String) {
+  repos(first: 10, after: $after, search: $search) {
+    totalCount
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    nodes {
+      id
+      meta {
+        creationDeadline
+        productionDeadline
+        briefingUrl
+      }
+      latestCommit {
+        id
+        date
+        message
+        document {
+          meta {
+            template
+            title
+            publishDate
+            credits
+          }
+        }
+      }
+      milestones {
+        name
+        immutable
+      }
+      latestPublications {
+        name
+        prepublication
+        live
+        scheduledAt
+        commit {
+          id
+          document {
+            meta {
+              slug
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+const ConnectedAutoComplete = graphql(repoQuery, {
+  skip: props => !props.filter,
+  options: ({ filter }) => ({ variables: { search: filter } }),
+  props: (props) => {
+    if (props.data.loading) return
+    const { data: { repos: { nodes = [] } } } = props
+    return ({
+      items: nodes.map(v => ({
+        value: v.id,
+        text: v.latestCommit.document.meta.title ||
+          v.id.replace([GITHUB_ORG, REPO_PREFIX || ''].join('/'), '')
+      }))
+    })
+  }
+})(Autocomplete)
+
+const safeValue = value =>
+  typeof value === 'string'
+  ? { value, text: value }
+  : null
+
+export default class RepoSearch extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      items: [],
+      filter: '',
+      value: safeValue(props.value)
+    }
+    this.filterChangeHandler = this.filterChangeHandler.bind(this)
+    this.changeHandler = this.changeHandler.bind(this)
+  }
+  componentDidMount () {
+    this._isMounted = true
+  }
+
+  componentWillUnmount () {
+    this._isMounted = false
+  }
+
+  componentWillReceiveProps (nextProps) {
+    this.setState({
+      ...this.state,
+      value: safeValue(nextProps.value)
+    })
+  }
+
+  filterChangeHandler (value) {
+    this.setState(
+        state => ({
+          ...this.state,
+          filter: value
+        })
+      )
+  }
+
+  changeHandler (value) {
+    this.setState(
+        state => ({
+          ...this.state,
+          value
+        }),
+        () => this.props.onChange(value)
+      )
+  }
+
+  render () {
+    const { filter, value } = this.state
+
+    return (
+      <ConnectedAutoComplete
+        label={this.props.label}
+        filter={filter}
+        value={value}
+        items={[]}
+        onChange={this.changeHandler}
+        onFilterChange={debounce(this.filterChangeHandler, 100)}
+        />
+    )
+  }
+}

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -18,7 +18,10 @@ query repos($after: String, $search: String) {
       latestCommit {
         document {
           meta {
-            format
+            format {
+              id
+              content
+            }
             title
             image
             description
@@ -39,7 +42,7 @@ const ConnectedAutoComplete = graphql(repoQuery, {
     const { data: { repos: { nodes = [] } } } = props
     return ({
       items: nodes.map(v => ({
-        value: v.id,
+        value: v,
         text: v.latestCommit.document.meta.title ||
           v.id.replace([GITHUB_ORG, REPO_PREFIX || ''].join('/'), '')
       }))
@@ -68,7 +71,6 @@ export default class RepoSearch extends Component {
 
   componentWillReceiveProps (nextProps) {
     this.setState({
-      ...this.state,
       value: safeValue(nextProps.value)
     })
   }

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -65,13 +65,6 @@ export default class RepoSearch extends Component {
     this.changeHandler = this.changeHandler.bind(this)
     this.setSearchValue = debounce(this.setSearchValue.bind(this), 500)
   }
-  componentDidMount () {
-    this._isMounted = true
-  }
-
-  componentWillUnmount () {
-    this._isMounted = false
-  }
 
   componentWillReceiveProps (nextProps) {
     this.setState({
@@ -82,7 +75,6 @@ export default class RepoSearch extends Component {
 
   setSearchValue () {
     this.setState({
-      ...this.state,
       search: this.state.filter
     })
   }
@@ -90,7 +82,6 @@ export default class RepoSearch extends Component {
   filterChangeHandler (value) {
     this.setState(
         state => ({
-          ...this.state,
           filter: value
         }),
         this.setSearchValue
@@ -100,7 +91,6 @@ export default class RepoSearch extends Component {
   changeHandler (value) {
     this.setState(
         state => ({
-          ...this.state,
           value
         }),
         () => this.props.onChange(value)

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -64,6 +64,7 @@ export default class RepoSearch extends Component {
       search: '',
       value: safeValue(props.value)
     }
+
     this.filterChangeHandler = this.filterChangeHandler.bind(this)
     this.changeHandler = this.changeHandler.bind(this)
     this.setSearchValue = debounce(this.setSearchValue.bind(this), 500)
@@ -73,6 +74,10 @@ export default class RepoSearch extends Component {
     this.setState({
       value: safeValue(nextProps.value)
     })
+  }
+
+  componentWillUnmount () {
+    this.setSearchValue.cancel()
   }
 
   setSearchValue () {

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -15,39 +15,14 @@ query repos($after: String, $search: String) {
     }
     nodes {
       id
-      meta {
-        creationDeadline
-        productionDeadline
-        briefingUrl
-      }
       latestCommit {
-        id
-        date
-        message
         document {
           meta {
-            template
+            format
             title
-            publishDate
+            image
+            description
             credits
-          }
-        }
-      }
-      milestones {
-        name
-        immutable
-      }
-      latestPublications {
-        name
-        prepublication
-        live
-        scheduledAt
-        commit {
-          id
-          document {
-            meta {
-              slug
-            }
           }
         }
       }

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -83,10 +83,12 @@ export default class RepoSearch extends Component {
     this.state = {
       items: [],
       filter: '',
+      search: '',
       value: safeValue(props.value)
     }
     this.filterChangeHandler = this.filterChangeHandler.bind(this)
     this.changeHandler = this.changeHandler.bind(this)
+    this.setSearchValue = debounce(this.setSearchValue.bind(this), 500)
   }
   componentDidMount () {
     this._isMounted = true
@@ -103,12 +105,20 @@ export default class RepoSearch extends Component {
     })
   }
 
+  setSearchValue () {
+    this.setState({
+      ...this.state,
+      search: this.state.filter
+    })
+  }
+
   filterChangeHandler (value) {
     this.setState(
         state => ({
           ...this.state,
           filter: value
-        })
+        }),
+        this.setSearchValue
       )
   }
 
@@ -123,16 +133,17 @@ export default class RepoSearch extends Component {
   }
 
   render () {
-    const { filter, value } = this.state
+    const { filter, value, search } = this.state
 
     return (
       <ConnectedAutoComplete
         label={this.props.label}
         filter={filter}
         value={value}
+        search={search}
         items={[]}
         onChange={this.changeHandler}
-        onFilterChange={debounce(this.filterChangeHandler, 100)}
+        onFilterChange={this.filterChangeHandler}
         />
     )
   }


### PR DESCRIPTION
Changelog:

- New `<SearchRepo />` component
- New customField config for meta forms: If property `ref` equals `repo` then use `<SearchRepo />`
