### PR TITLE
fix break in marks

### DIFF
--- a/components/Templates/index.js
+++ b/components/Templates/index.js
@@ -6,8 +6,10 @@ import createArticleSchema from '@project-r/styleguide/lib/templates/Article'
 import createFrontSchema from '@project-r/styleguide/lib/templates/Front'
 
 const schemas = {
-  editorialNewsletter: editorialNewsletterSchema(),
+  // first is default schema for the editor
+  // - for Project R this should be the newsletter
   newsletter: newsletterSchema,
+  editorialNewsletter: editorialNewsletterSchema(),
   neutrum: neutrumSchema,
   article: createArticleSchema(),
   front: createFrontSchema()

--- a/components/editor/modules/figure/caption.js
+++ b/components/editor/modules/figure/caption.js
@@ -23,7 +23,7 @@ const getSerializer = options => {
             node.type === 'break',
           fromMdast: () => ({
             kind: 'text',
-            leaves: [{ text: '\n' }]
+            leaves: [{kind: 'leaf', text: '\n', marks: []}]
           })
         })
     }

--- a/components/editor/modules/figure/serializer.test.js
+++ b/components/editor/modules/figure/serializer.test.js
@@ -3,6 +3,7 @@ import createFigureModule from './'
 import createImageModule from './image'
 import createCaptionModule from './caption'
 import { parse, stringify } from '@orbiting/remark-preset'
+import { boldModule } from '../mark/testUtils'
 
 const TYPE = 'FIGURE'
 
@@ -22,7 +23,7 @@ const captionModule = createCaptionModule({
   rule: {
     matchMdast: node => node.type === 'paragraph'
   },
-  subModules: []
+  subModules: [boldModule]
 })
 captionModule.name = 'figureCaption'
 
@@ -63,5 +64,22 @@ Caption
   assert.equal(caption.text, 'Caption')
 
   assert.equal(stringify(serializer.serialize(value)).trimRight(), md)
+  assert.end()
+})
+
+test('figure caption with break in mark', assert => {
+  const serializer = captionModule.helpers.serializer
+
+  const md = `A**${'  '}
+B**
+`
+  const value = serializer.deserialize(parse(md))
+  const node = value.document.nodes.first()
+
+  assert.equal(node.kind, 'block')
+  assert.equal(node.type, 'FIGURE_CAPTION')
+  assert.equal(node.text, 'A\nB')
+
+  assert.equal(stringify(serializer.serialize(value)), md)
   assert.end()
 })

--- a/components/editor/modules/mark/serializer.test.js
+++ b/components/editor/modules/mark/serializer.test.js
@@ -1,65 +1,6 @@
 import test from 'tape'
-import createMarkModule from './'
-import createParagraphModule from '../paragraph'
+import { paragraphModule } from './testUtils'
 import { parse, stringify } from '@orbiting/remark-preset'
-
-const boldModule = createMarkModule({
-  TYPE: 'STRONG',
-  rule: {
-    matchMdast: node => node.type === 'strong',
-    editorOptions: {
-      type: 'strong'
-    }
-  },
-  subModules: []
-})
-const emphasisModule = createMarkModule({
-  TYPE: 'EMPHASIS',
-  rule: {
-    matchMdast: node => node.type === 'emphasis',
-    editorOptions: {
-      type: 'emphasis'
-    }
-  },
-  subModules: []
-})
-const deleteModule = createMarkModule({
-  TYPE: 'DELETE',
-  rule: {
-    matchMdast: node => node.type === 'delete',
-    editorOptions: {
-      type: 'delete'
-    }
-  },
-  subModules: []
-})
-const subModule = createMarkModule({
-  TYPE: 'SUB',
-  rule: {
-    matchMdast: node => node.type === 'sub',
-    editorOptions: {
-      type: 'sub'
-    }
-  },
-  subModules: []
-})
-const supModule = createMarkModule({
-  TYPE: 'SUP',
-  rule: {
-    matchMdast: node => node.type === 'sup',
-    editorOptions: {
-      type: 'sup'
-    }
-  },
-  subModules: []
-})
-
-const paragraphModule = createParagraphModule({
-  TYPE: 'P',
-  rule: {},
-  subModules: [boldModule, emphasisModule, deleteModule, subModule, supModule]
-})
-paragraphModule.name = 'paragraph'
 
 const serializer = paragraphModule.helpers.serializer
 

--- a/components/editor/modules/mark/testUtils.js
+++ b/components/editor/modules/mark/testUtils.js
@@ -1,0 +1,60 @@
+import createMarkModule from './'
+import createParagraphModule from '../paragraph'
+
+export const boldModule = createMarkModule({
+  TYPE: 'STRONG',
+  rule: {
+    matchMdast: node => node.type === 'strong',
+    editorOptions: {
+      type: 'strong'
+    }
+  },
+  subModules: []
+})
+export const emphasisModule = createMarkModule({
+  TYPE: 'EMPHASIS',
+  rule: {
+    matchMdast: node => node.type === 'emphasis',
+    editorOptions: {
+      type: 'emphasis'
+    }
+  },
+  subModules: []
+})
+export const deleteModule = createMarkModule({
+  TYPE: 'DELETE',
+  rule: {
+    matchMdast: node => node.type === 'delete',
+    editorOptions: {
+      type: 'delete'
+    }
+  },
+  subModules: []
+})
+export const subModule = createMarkModule({
+  TYPE: 'SUB',
+  rule: {
+    matchMdast: node => node.type === 'sub',
+    editorOptions: {
+      type: 'sub'
+    }
+  },
+  subModules: []
+})
+export const supModule = createMarkModule({
+  TYPE: 'SUP',
+  rule: {
+    matchMdast: node => node.type === 'sup',
+    editorOptions: {
+      type: 'sup'
+    }
+  },
+  subModules: []
+})
+
+export const paragraphModule = createParagraphModule({
+  TYPE: 'P',
+  rule: {},
+  subModules: [boldModule, emphasisModule, deleteModule, subModule, supModule]
+})
+paragraphModule.name = 'paragraph'

--- a/components/editor/modules/paragraph/index.js
+++ b/components/editor/modules/paragraph/index.js
@@ -21,7 +21,7 @@ export default ({rule, subModules, TYPE}) => {
       matchMdast: (node) => node.type === 'break',
       fromMdast: () => ({
         kind: 'text',
-        leaves: [{text: '\n'}]
+        leaves: [{kind: 'leaf', text: '\n', marks: []}]
       })
     })
   })

--- a/components/editor/modules/paragraph/serializer.test.js
+++ b/components/editor/modules/paragraph/serializer.test.js
@@ -1,16 +1,17 @@
 import test from 'tape'
 import createParagraphModule from './'
 import { parse, stringify } from '@orbiting/remark-preset'
-
-const paragraphModule = createParagraphModule({
-  TYPE: 'P',
-  rule: {},
-  subModules: []
-})
-
-const serializer = paragraphModule.helpers.serializer
+import { boldModule } from '../mark/testUtils'
 
 test('paragraph serialization', assert => {
+  const paragraphModule = createParagraphModule({
+    TYPE: 'P',
+    rule: {},
+    subModules: []
+  })
+
+  const serializer = paragraphModule.helpers.serializer
+
   const value = serializer.deserialize(parse('Test'))
   const node = value.document.nodes.first()
 
@@ -19,5 +20,28 @@ test('paragraph serialization', assert => {
   assert.equal(node.text, 'Test')
 
   assert.equal(stringify(serializer.serialize(value)).trimRight(), 'Test')
+  assert.end()
+})
+
+test('paragraph with break in mark', assert => {
+  const paragraphModule = createParagraphModule({
+    TYPE: 'P',
+    rule: {},
+    subModules: [boldModule]
+  })
+
+  const serializer = paragraphModule.helpers.serializer
+
+  const md = `A**${'  '}
+B**
+`
+  const value = serializer.deserialize(parse(md))
+  const node = value.document.nodes.first()
+
+  assert.equal(node.kind, 'block')
+  assert.equal(node.type, 'P')
+  assert.equal(node.text, 'A\nB')
+
+  assert.equal(stringify(serializer.serialize(value)), md)
   assert.end()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
       }
     },
     "@project-r/template-newsletter": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@project-r/template-newsletter/-/template-newsletter-1.4.3.tgz",
-      "integrity": "sha512-jufCZrQGBPTDoEBCzkHeeS4ZE3N5bTTjscyhI5goXTDbarRe/EoKVilJCLJtA8p9EWEm1pydaYfBJmNLjAONSA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@project-r/template-newsletter/-/template-newsletter-1.5.0.tgz",
+      "integrity": "sha512-+cbLXsuSUEHEjLVSJaZQ/lwQiPt84zf43o4Ph0rexHfnfu4MrenyZOVJUQEVd/9ijYmVCVzK89sW3trrK6WCKQ=="
     },
     "@semantic-release/commit-analyzer": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.1",
     "@project-r/styleguide": "^5.24.0",
-    "@project-r/template-newsletter": "^1.4.3",
+    "@project-r/template-newsletter": "^1.5.0",
     "d3-array": "^1.2.0",
     "d3-color": "^1.0.3",
     "d3-format": "^1.2.1",


### PR DESCRIPTION
The deserialization rule for mdast `break` returned an incomplete slate json which could not handle marks.