### PR TITLE
fix mdastPlaceholders in lead

### DIFF
--- a/components/editor/modules/paragraph/index.js
+++ b/components/editor/modules/paragraph/index.js
@@ -63,7 +63,7 @@ export default ({rule, subModules, TYPE}) => {
           (
             children.length === 1 &&
             children[0].type === 'text' &&
-            !(children[0].text || '').trim()
+            !(children[0].value || '').trim()
           )
         ) {
           children = [{type: 'text', value: mdastPlaceholder}]


### PR DESCRIPTION
See in diff:
paragraph module assumes already serialized values, therefore it will replace children in everything with the option `mdastPlaceholder` set. 
