### PR TITLE
fix figurecaption serializer

### DIFF
--- a/components/editor/modules/figure/caption.js
+++ b/components/editor/modules/figure/caption.js
@@ -92,15 +92,21 @@ const getSerializer = options => {
     ]
     const bylineChildren = bylineModule.helpers.serializer.toMdast(
         byline.nodes,
-        0,
+        1,
         object,
         rest
     )
 
-    if (bylineChildren.length && bylineChildren[0].value !== '') {
+    if (
+      bylineChildren.length &&
+      !(
+        bylineChildren.length === 1 &&
+        bylineChildren[0].value === ''
+      )
+    ) {
       children.push({
         type: 'emphasis',
-        children: bylineModule.helpers.serializer.toMdast(byline.nodes)
+        children: bylineChildren
       })
     }
 

--- a/components/editor/modules/figure/caption.js
+++ b/components/editor/modules/figure/caption.js
@@ -82,20 +82,31 @@ const getSerializer = options => {
       byline
     ] = object.nodes
 
+    const children = [
+      ...inlineSerializer.toMdast(
+        caption.nodes,
+        0,
+        object,
+        rest
+      )
+    ]
+    const bylineChildren = bylineModule.helpers.serializer.toMdast(
+        byline.nodes,
+        0,
+        object,
+        rest
+    )
+
+    if (bylineChildren.length && bylineChildren[0].value !== '') {
+      children.push({
+        type: 'emphasis',
+        children: bylineModule.helpers.serializer.toMdast(byline.nodes)
+      })
+    }
+
     const res = {
       type: 'paragraph',
-      children: [
-        ...inlineSerializer.toMdast(
-          caption.nodes,
-          0,
-          object,
-          rest
-        ),
-        {
-          type: 'emphasis',
-          children: bylineModule.helpers.serializer.toMdast(byline.nodes)
-        }
-      ]
+      children
     }
     return res
   }


### PR DESCRIPTION
Omit emphasis from mdast when byline is empty. 