### PR TITLE
extends series form with cover text options

### DIFF
--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-18T03:07:01.645Z",
+  "updated": "2018-01-18T22:08:51.558Z",
   "title": "live",
   "data": [
     {
@@ -311,6 +311,10 @@
       "value": "Bildbeschrieb"
     },
     {
+      "key": "metaData/field/label",
+      "value": "Label"
+    },
+    {
       "key": "metaData/field/captionRight",
       "value": "Bildlegende rechts"
     },
@@ -367,6 +371,10 @@
       "value": "Master"
     },
     {
+      "key": "metaData/series/title/label",
+      "value": "Title"
+    },
+    {
       "key": "metaData/series/episode",
       "value": "Episode"
     },
@@ -385,6 +393,22 @@
     {
       "key": "metaData/series/episodes/document",
       "value": "Dokument"
+    },
+    {
+      "key": "metaData/series/coverText/anchor",
+      "value": "Text auf Cover"
+    },
+    {
+      "key": "metaData/series/coverText/offset",
+      "value": "Offset (CSS Units)"
+    },
+    {
+      "key": "metaData/series/coverText/color",
+      "value": "Farbe"
+    },
+    {
+      "key": "metaData/series/coverText/fontSize",
+      "value": "Schriftgrösse"
     },
     {
       "key": "uncommittedChanges/title",
@@ -524,7 +548,7 @@
     },
     {
       "key": "publish/error/unresolvedRepoIds/template",
-      "value": "Sie können diese Publikation durchführen solange nicht alle Referenzen zur Veröffentlichung ferigegeben sind."
+      "value": "Sie können diese Publikation nicht durchführen solange nicht alle Referenzen zur Veröffentlichung ferigegeben sind."
     },
     {
       "key": "publication/current/title/1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.42.0.tgz",
-      "integrity": "sha1-vMAmbtFS7KVVufIh2m19JSqxzI4=",
+      "version": "5.44.2",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.44.2.tgz",
+      "integrity": "sha1-ulRW14Wm10+KifqAhynxdfvbuYw=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.1",
-    "@project-r/styleguide": "^5.42.0",
+    "@project-r/styleguide": "^5.44.2",
     "@project-r/template-newsletter": "^1.5.0",
     "d3-array": "^1.2.0",
     "d3-color": "^1.0.3",


### PR DESCRIPTION
this it far from ideal, it's for a desktop only text on cover mode

<img width="685" alt="screen shot 2018-01-18 at 23 22 54" src="https://user-images.githubusercontent.com/410211/35124492-8fd09b04-fca6-11e7-8128-e5fa6cf537eb.png">

_we miss managed the requirements process so we get a cover text image via meta data_