### PR TITLE
Publish Date and URL

### DIFF
--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -390,6 +390,7 @@ query repos($after: String, $search: String, $orderBy: RepoOrderBy) {
         live
         scheduledAt
         document {
+          id
           meta {
             path
             slug

--- a/components/editor/UI.js
+++ b/components/editor/UI.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
-import { initModule, getAllModules, getFromModules } from './'
+import { getFromModules } from './'
 import { Interaction, Label, colors } from '@project-r/styleguide'
+import PropTypes from 'prop-types'
 
 const Sidebar = ({
   textFormatButtons,
@@ -60,15 +61,11 @@ const Sidebar = ({
   </div>
 )
 
-export default class extends Component {
+class UISidebar extends Component {
   constructor (props, ...args) {
     super(props, ...args)
 
-    const rootRule = props.schema.rules[0]
-    const rootModule = initModule(rootRule)
-
-    const allModules = getAllModules(rootModule)
-    const uniqModules = allModules.filter((m, i, a) => a.findIndex(mm => mm.TYPE === m.TYPE) === i)
+    const { uniqModules } = props.editorRef
 
     this.textFormatButtons = getFromModules(
       uniqModules,
@@ -106,3 +103,14 @@ export default class extends Component {
     )
   }
 }
+
+UISidebar.propTypes = {
+  editorRef: PropTypes.shape({
+    uniqModules: PropTypes.array.isRequired,
+    slate: PropTypes.shape({
+      change: PropTypes.func.isRequired
+    }).isRequired
+  }).isRequired
+}
+
+export default UISidebar

--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -140,7 +140,8 @@ class Editor extends Component {
     }
     const rootRule = schema.rules[0]
     const rootModule = initModule(rootRule, {
-      mdastSchema: schema
+      mdastSchema: schema,
+      meta: props.meta
     })
 
     this.serializer = rootModule.helpers.serializer

--- a/components/editor/modules/meta/index.js
+++ b/components/editor/modules/meta/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import MetaData from './ui'
 
-export default ({rule, TYPE}) => {
+export default ({rule, TYPE, context = {}}) => {
   const options = rule.editorOptions || {}
 
   return {
@@ -16,7 +16,9 @@ export default ({rule, TYPE}) => {
             <div>
               {children}
               <MetaData value={value} editor={editor}
-                {...options} />
+                {...options}
+                mdastSchema={context.mdastSchema}
+                contextMeta={context.meta} />
             </div>
           )
         }

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -5,6 +5,8 @@ import { Map, Set } from 'immutable'
 import { Interaction, Dropdown, Field, Label, colors } from '@project-r/styleguide'
 
 import withT from '../../../../lib/withT'
+import slugify from '../../../../lib/utils/slug'
+
 import MetaForm from '../../utils/MetaForm'
 import SlugField from '../../utils/SlugField'
 import FBPreview from './FBPreview'
@@ -27,7 +29,7 @@ const styles = {
 
 const getWidth = key => key.match(/title|feed|emailSubject/i) ? '100%' : ''
 
-const MetaData = ({value, editor, series, additionalFields = [], customFields = [], teaser: Teaser, t}) => {
+const MetaData = ({value, editor, mdastSchema, contextMeta, series, additionalFields = [], customFields = [], teaser: Teaser, t}) => {
   const node = value.document
 
   const genericKeys = Set([
@@ -76,6 +78,9 @@ const MetaData = ({value, editor, series, additionalFields = [], customFields = 
         })
     })
   }
+
+  const dataAsJs = node.data.toJS()
+
   return (
     <div {...styles.container}>
       <div {...styles.center}>
@@ -89,6 +94,16 @@ const MetaData = ({value, editor, series, additionalFields = [], customFields = 
           value={node.data.get('slug')}
           onChange={onInputChange('slug')}
         />
+        {mdastSchema && mdastSchema.getPath &&
+          <Label>{t('metaData/field/slug/note', {
+            path: mdastSchema.getPath({
+              ...dataAsJs,
+              publishDate: contextMeta.publishDate
+                ? new Date(contextMeta.publishDate)
+                : new Date(),
+              slug: slugify(dataAsJs.slug || '')
+            })
+          })}<br /><br /></Label>}
         <MetaForm data={genericData} onInputChange={onInputChange} black getWidth={getWidth} />
         <UIForm getWidth={() => '50%'}>
           {customFields.map(customField => {
@@ -145,7 +160,7 @@ const MetaData = ({value, editor, series, additionalFields = [], customFields = 
         {!!series && <SeriesForm editor={editor} node={node} />}
         {!!Teaser && (<div>
           <Label>{t('metaData/preview')}</Label><br />
-          <Teaser {...node.data.toJS()} />
+          <Teaser {...dataAsJs} />
         </div>)}
         <br /><br /><br />
         <MetaForm data={fbData} onInputChange={onInputChange} black getWidth={getWidth} />

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-20T22:12:01.520Z",
+  "updated": "2018-02-01T19:11:17.097Z",
   "title": "live",
   "data": [
     {
@@ -309,6 +309,10 @@
     {
       "key": "metaData/field/slug",
       "value": "Web-Slug"
+    },
+    {
+      "key": "metaData/field/slug/note",
+      "value": "Ergibt folgende URL: republik.ch{path}"
     },
     {
       "key": "metaData/field/src",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-02-01T19:11:17.097Z",
+  "updated": "2018-02-01T19:56:33.474Z",
   "title": "live",
   "data": [
     {
@@ -517,6 +517,18 @@
     {
       "key": "publish/commit/change",
       "value": "Version ändern"
+    },
+    {
+      "key": "publish/meta/date/label",
+      "value": "Publikationsdatum"
+    },
+    {
+      "key": "publish/meta/path/label",
+      "value": "URL"
+    },
+    {
+      "key": "publish/meta/path/value",
+      "value": "republik.ch{path}"
     },
     {
       "key": "publish/trigger",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.50.0.tgz",
-      "integrity": "sha1-S6/HSXbn1bD+Td4u9r8hb1aQBHQ=",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.51.0.tgz",
+      "integrity": "sha1-3IOPD5bJaJP2W3R5WzleqUg/7xc=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.1",
-    "@project-r/styleguide": "^5.50.0",
+    "@project-r/styleguide": "^5.51.0",
     "@project-r/template-newsletter": "^1.5.0",
     "d3-array": "^1.2.0",
     "d3-color": "^1.0.3",

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -136,6 +136,10 @@ class EditorPage extends Component {
       this.documentChangeHandler.bind(this),
       500
     )
+    this.uiChangeHandler = change => {
+      this.changeHandler(change)
+      this.documentChangeHandler(null, change)
+    }
     this.revertHandler = this.revertHandler.bind(this)
 
     this.editorRef = ref => {
@@ -519,7 +523,7 @@ class EditorPage extends Component {
                 <Sidebar.Tab tabId='edit' label='Editieren'>
                   {!!this.editor && <EditorUI
                     editorRef={this.editor}
-                    onChange={this.changeHandler}
+                    onChange={this.uiChangeHandler}
                     value={editorState}
                   />}
                 </Sidebar.Tab>

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -140,6 +140,9 @@ class EditorPage extends Component {
 
     this.editorRef = ref => {
       this.editor = ref
+      if (ref) {
+        this.forceUpdate()
+      }
     }
 
     this.state = {
@@ -514,11 +517,11 @@ class EditorPage extends Component {
               />
               <Sidebar selectedTabId='edit' isOpen={showSidebar}>
                 <Sidebar.Tab tabId='edit' label='Editieren'>
-                  <EditorUI
-                    schema={schema}
+                  {!!this.editor && <EditorUI
+                    editorRef={this.editor}
                     onChange={this.changeHandler}
                     value={editorState}
-                  />
+                  />}
                 </Sidebar.Tab>
                 <Sidebar.Tab tabId='workflow' label='Workflow'>
                   <VersionControl

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -68,6 +68,9 @@ const fragments = {
   repo: gql`
     fragment EditPageRepo on Repo {
       id
+      meta {
+        publishDate
+      }
     }
   `
 }
@@ -515,6 +518,7 @@ class EditorPage extends Component {
               <Editor
                 ref={this.editorRef}
                 schema={schema}
+                meta={repo ? repo.meta : {}}
                 value={editorState}
                 onChange={this.changeHandler}
                 onDocumentChange={this.documentChangeHandler}


### PR DESCRIPTION
Make Publish Date and the URL more visible.

Depends on https://github.com/orbiting/styleguide/pull/97

Show in meta data:
<img width="676" alt="screen shot 2018-02-01 at 20 32 22" src="https://user-images.githubusercontent.com/410211/35701049-17bc6572-0795-11e8-9dab-1600bec03253.png">
<img width="667" alt="screen shot 2018-02-01 at 20 32 50" src="https://user-images.githubusercontent.com/410211/35701050-17d7f468-0795-11e8-8357-0fb8a376be0e.png">
<img width="673" alt="screen shot 2018-02-01 at 20 32 37" src="https://user-images.githubusercontent.com/410211/35701052-17f5c77c-0795-11e8-8909-50a8e0be265c.png">

and publish form:
<img width="696" alt="screen shot 2018-02-01 at 21 16 22" src="https://user-images.githubusercontent.com/410211/35701081-2f545334-0795-11e8-9137-3665bd3ef8be.png">
_and also prefill scheduled at with the publish date if it's in the future_