### PR TITLE
CSS iframe updates & npm run link:sg

### DIFF
--- a/components/IFrame/index.js
+++ b/components/IFrame/index.js
@@ -2,6 +2,9 @@ import React, { Component } from 'react'
 import { styleSheet } from 'glamor'
 import Frame from 'react-frame-component'
 import PropTypes from 'prop-types'
+import createDebug from 'debug'
+
+const debug = createDebug('publikator:iframe')
 
 class IFrame extends Component {
   constructor (...args) {
@@ -28,9 +31,13 @@ class IFrame extends Component {
     window.removeEventListener('resize', this.measure)
   }
   transferCSS () {
-    this.setState({
-      css: styleSheet.rules().map(r => r.cssText).join('')
-    })
+    const css = styleSheet.rules().map(r => r.cssText).join('')
+    if (css !== this.state.css) {
+      debug('transfer css', {css})
+      this.setState({
+        css
+      })
+    }
   }
   render () {
     const {
@@ -58,6 +65,7 @@ class IFrame extends Component {
           <Frame
             frameBorder='0'
             contentDidMount={() => this.transferCSS()}
+            contentDidUpdate={() => this.transferCSS()}
             head={[
               <style key='glamor'>{css}</style>
             ]}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "cross-env NODE_ENV=test babel-tape-runner \"?(lib|pages|components)/**/*.test.js\" | faucet",
     "standardize": "standard --fix",
     "precommit": "npm test && lint-staged",
-    "translations": "gsheets --key=1qPubCKz2YzbcFkRfF0MrgRqD0KLsgRPxoZfG5G3tHOA --title=live --pretty --out lib/translations.json"
+    "translations": "gsheets --key=1qPubCKz2YzbcFkRfF0MrgRqD0KLsgRPxoZfG5G3tHOA --title=live --pretty --out lib/translations.json",
+    "link:sg": "rm -rf .next && npm link @project-r/styleguide && rm -rf node_modules/glamor && ln -s @project-r/styleguide/node_modules/glamor node_modules/glamor && echo '\n⚠️  Make sure to restart the next.js server\n'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Ensure CSS is transfered from the parent to the iframe on iframe updates.

Additionally a `npm run link:sg` util task to link the styleguide and glamor (use glamor from the styleguide).