### PR TITLE
enable "onlyImage" checkbox on front tile teaser

### DIFF
--- a/components/editor/modules/teaser/index.js
+++ b/components/editor/modules/teaser/index.js
@@ -28,6 +28,7 @@ export const getData = data => ({
   reverse: false,
   portrait: true,
   showImage: true,
+  onlyImage: false,
   ...data || {}
 })
 

--- a/components/editor/modules/teaser/ui.js
+++ b/components/editor/modules/teaser/ui.js
@@ -286,6 +286,15 @@ const Form = withT(({ node, onChange, options, t }) => {
         Bild anzeigen
       </Checkbox>
     }
+    {
+      options.includes('onlyImage') &&
+      <Checkbox
+        checked={node.data.get('onlyImage')}
+        onChange={onChange('onlyImage')}
+      >
+        Nur Bild
+      </Checkbox>
+    }
   </UIForm>
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "5.50.9",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.50.9.tgz",
-      "integrity": "sha1-J/OGKr8YavGbnBBFq7pUmsmAp+M=",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.53.0.tgz",
+      "integrity": "sha1-/jIm2HqkApe/CZMc93XGco/Awhk=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.1",
-    "@project-r/styleguide": "^5.50.9",
+    "@project-r/styleguide": "^5.53.0",
     "@project-r/template-newsletter": "^1.5.0",
     "d3-array": "^1.2.0",
     "d3-color": "^1.0.3",


### PR DESCRIPTION
depends on https://github.com/orbiting/styleguide/pull/99

editor UI:
![screen shot 2018-02-07 at 11 33 36](https://user-images.githubusercontent.com/23520051/35911809-28d03482-0bfb-11e8-80ee-30572ce21751.png)

published tile (ugly content on purpose):
![screen shot 2018-02-07 at 11 30 55](https://user-images.githubusercontent.com/23520051/35911833-357f4128-0bfb-11e8-99f9-ff417085c939.png)

