### PR TITLE
User and Repo Search improvements

### DIFF
--- a/components/editor/modules/link/ui.js
+++ b/components/editor/modules/link/ui.js
@@ -17,9 +17,10 @@ import {
 
 const usersQuery = gql`
 query users($search: String!) {
-  users(search: $search, role: "editor") {
+  users(search: $search) {
     firstName
     lastName
+    email
     id
   }
 }
@@ -29,8 +30,8 @@ const ConnectedAutoComplete = graphql(usersQuery, {
   options: ({ filter }) => ({ variables: { search: filter } }),
   props: ({ data: { users = [] } }) => ({
     items: users.slice(0, 5).map(v => ({
-      value: v.id,
-      text: `${v.firstName} ${v.lastName}`
+      value: v,
+      text: v.email
     }))
   })
 })(Autocomplete)
@@ -96,11 +97,11 @@ const Form = options => ({ value, onChange, t }) => {
           type: TYPE,
           kind: 'inline',
           data: node.data.merge({
-            title: author.text,
-            href: `/~${author.value}`
+            title: `${author.value.firstName} ${author.value.lastName}`,
+            href: `/~${author.value.id}`
           }),
           nodes: [
-            Text.create(author.text)
+            Text.create(`${author.value.firstName} ${author.value.lastName}`)
           ]
         }
       )

--- a/components/editor/modules/link/ui.js
+++ b/components/editor/modules/link/ui.js
@@ -59,7 +59,7 @@ const SearchUserForm = withT(class extends Component {
   changeHandler (value) {
     this.setState(
         state => ({
-          ...this.state,
+          filter: null,
           value: null
         }),
         () => this.props.onChange(value)

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -118,7 +118,8 @@ export default class RepoSearch extends Component {
   changeHandler (value) {
     this.setState(
         state => ({
-          value
+          value: null,
+          filter: null
         }),
         () => this.props.onChange(value)
       )


### PR DESCRIPTION
- Clears input after value was selected for both user and repo search widgets in link UI
- Remove static role filter from user search. Depends on https://github.com/orbiting/backends/pull/21
- Display email address instead of name in user search widget 