### PR TITLE
Sub/Sup in headlines / Front restricted to 100 Teasers

### DIFF
--- a/components/editor/modules/front/index.js
+++ b/components/editor/modules/front/index.js
@@ -12,15 +12,19 @@ export default ({rule, subModules, TYPE}) => {
     ).filter(Boolean)
   })
 
+  let invisibleNodes
+
   const documentRule = {
     match: object => object.kind === 'document',
     matchMdast: rule.matchMdast,
     fromMdast: (node, index, parent, rest) => {
+      const visibleNodes = node.children.slice(0, 100)
+      invisibleNodes = node.children.slice(100)
       const res = {
         document: {
           data: node.meta,
           kind: 'document',
-          nodes: childSerializer.fromMdast(node.children)
+          nodes: childSerializer.fromMdast(visibleNodes)
         },
         kind: 'value'
       }
@@ -30,7 +34,7 @@ export default ({rule, subModules, TYPE}) => {
       return {
         type: 'root',
         meta: object.data,
-        children: childSerializer.toMdast(object.nodes)
+        children: childSerializer.toMdast(object.nodes).concat(invisibleNodes)
       }
     }
   }

--- a/components/editor/modules/headline/index.js
+++ b/components/editor/modules/headline/index.js
@@ -29,13 +29,6 @@ export default ({ rule, subModules, TYPE }) => {
         ),
         []
       ).filter(Boolean)
-      // .concat({
-      //   matchMdast: (node) => node.type === 'break',
-      //   fromMdast: () => ({
-      //     kind: 'text',
-      //     leaves: [{kind: 'leaf', text: '\n', marks: []}]
-      //   })
-      // })
   })
 
   const title = {


### PR DESCRIPTION

* Sub/Sup was not available in headlines module due to inexplicit child parsing.
* Front renders only the latest / first 100 Teasers