### PR TITLE
Improve Usability on Small Displays and Get Ride of Unnecessary Scrollbars

### DIFF
--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -29,7 +29,8 @@ const styles = {
     borderLeft: `1px solid ${colors.divider}`,
     opacity: 1,
     zIndex: ZINDEX_SIDEBAR,
-    padding: 10
+    // ensure 10px white space for <UIForm>s negative magins
+    padding: 10 + 1 * 2 // 1px border
   }),
   overlay: css({
     opacity: '0.5',

--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -3,23 +3,33 @@ import { css } from 'glamor'
 import { HEADER_HEIGHT, ZINDEX_SIDEBAR } from '../Frame/constants'
 import { colors, Label } from '@project-r/styleguide'
 
+const SIDEBAR_WIDTH_SMALL = 270
+const SIDEBAR_WIDTH_LARGE = 340
+
 const styles = {
   container: css({
     position: 'fixed',
     top: HEADER_HEIGHT,
-    right: -340,
+    width: SIDEBAR_WIDTH_SMALL,
+    right: -SIDEBAR_WIDTH_SMALL,
+    transition: 'right 0.2s ease',
+    '&.open': {
+      right: 0
+    },
+    '@media only screen and (min-width: 1400px)': {
+      width: SIDEBAR_WIDTH_LARGE,
+      right: -SIDEBAR_WIDTH_LARGE,
+      '&.open': {
+        right: 0
+      }
+    },
     bottom: 0,
-    width: 340,
     overflow: 'auto',
     backgroundColor: '#fff',
     borderLeft: `1px solid ${colors.divider}`,
     opacity: 1,
     zIndex: ZINDEX_SIDEBAR,
-    padding: 10,
-    transition: 'right 0.2s ease',
-    '&.open': {
-      right: 0
-    }
+    padding: 10
   }),
   overlay: css({
     opacity: '0.5',

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -11,6 +11,7 @@ import withData from '../../lib/apollo/withData'
 import withAuthorization from '../../components/Auth/withAuthorization'
 
 import Frame from '../../components/Frame'
+import { HEADER_HEIGHT } from '../../components/Frame/constants'
 import RepoNav from '../../components/Repo/Nav'
 
 import Editor from '../../components/editor'
@@ -141,6 +142,8 @@ const rmWarning = message => state => ({
   warnings: state.warnings
     .filter(warning => warning !== message)
 })
+
+const SIDEBAR_ICON_SIZE = 30
 
 export class EditorPage extends Component {
   constructor (...args) {
@@ -667,12 +670,15 @@ export class EditorPage extends Component {
               style={{
                 padding: 25,
                 paddingTop: 30,
+                paddingBottom: (
+                  HEADER_HEIGHT - SIDEBAR_ICON_SIZE - 30 - 1 // 1 px header border
+                ),
                 cursor: 'pointer',
                 color: showSidebar ? colors.primary : undefined
               }}
               onMouseDown={this.toggleSidebarHandler}
             >
-              <SettingsIcon size='30' />
+              <SettingsIcon size={SIDEBAR_ICON_SIZE} />
             </div>
           </Frame.Header.Section>
           <Frame.Header.Section align='right'>


### PR DESCRIPTION
Before
<img width="1465" alt="before" src="https://user-images.githubusercontent.com/410211/45151006-74282480-b1cd-11e8-995a-d8f76ff546e1.png">

After
<img width="1465" alt="after" src="https://user-images.githubusercontent.com/410211/45151018-7c805f80-b1cd-11e8-8002-64a94476baae.png">

_Urs asked me to reduce the sidebar size in order to keep it open while writing. Reducing it by 70px on smaller displays seems to work fine and won't impact heavy sidebar form users on larger displays._