### PR TITLE
Decorate Invisible Characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '8'
+  - '10.4.1'
 script:
   - npm run test
   - npm run build

--- a/components/editor/modules/specialchars/index.js
+++ b/components/editor/modules/specialchars/index.js
@@ -119,7 +119,7 @@ const NBSPButton = ({ value, onChange }) => {
   </span>
 }
 
-const softHypenClickHandler = (value, onChange) => event => {
+const softHyphenClickHandler = (value, onChange) => event => {
   event.preventDefault()
 
   return onChange(
@@ -129,13 +129,13 @@ const softHypenClickHandler = (value, onChange) => event => {
   )
 }
 
-const SoftHypenButton = ({ value, onChange }) => {
+const SoftHyphenButton = ({ value, onChange }) => {
   const disabled = value.isBlurred
   return <span
     {...buttonStyles.insert}
     data-disabled={disabled}
     data-visible
-    onMouseDown={softHypenClickHandler(value, onChange)}
+    onMouseDown={softHyphenClickHandler(value, onChange)}
       >
     Silbentrennung (‧)
   </span>
@@ -155,7 +155,7 @@ export default ({ TYPE }) => ({
       SingleGuillemetButton,
       LongDashButton,
       NBSPButton,
-      SoftHypenButton
+      SoftHyphenButton
     ]
   }
 })

--- a/components/editor/modules/specialchars/index.js
+++ b/components/editor/modules/specialchars/index.js
@@ -1,4 +1,5 @@
 import { buttonStyles } from '../../utils'
+import invisibleDecoratorPlugin from './invisibleDecoratorPlugin'
 
 const doubleGuillemetClickHandler = (value, onChange) => event => {
   event.preventDefault()
@@ -123,7 +124,9 @@ export default ({ TYPE }) => ({
   helpers: {
   },
   changes: {},
-  plugins: [],
+  plugins: [
+    invisibleDecoratorPlugin()
+  ],
   ui: {
     insertButtons: [
       DoubleGuillemetButton,

--- a/components/editor/modules/specialchars/index.js
+++ b/components/editor/modules/specialchars/index.js
@@ -107,7 +107,7 @@ const nbspClickHandler = (value, onChange) => event => {
   )
 }
 
-const NBSPDashButton = ({ value, onChange }) => {
+const NBSPButton = ({ value, onChange }) => {
   const disabled = value.isBlurred
   return <span
     {...buttonStyles.insert}
@@ -115,7 +115,29 @@ const NBSPDashButton = ({ value, onChange }) => {
     data-visible
     onMouseDown={nbspClickHandler(value, onChange)}
       >
-    Dauerleerzeichen
+    Dauerleerzeichen (␣)
+  </span>
+}
+
+const softHypenClickHandler = (value, onChange) => event => {
+  event.preventDefault()
+
+  return onChange(
+    value
+      .change()
+      .insertText('\u00ad')
+  )
+}
+
+const SoftHypenButton = ({ value, onChange }) => {
+  const disabled = value.isBlurred
+  return <span
+    {...buttonStyles.insert}
+    data-disabled={disabled}
+    data-visible
+    onMouseDown={softHypenClickHandler(value, onChange)}
+      >
+    Silbentrennung (‧)
   </span>
 }
 
@@ -132,7 +154,8 @@ export default ({ TYPE }) => ({
       DoubleGuillemetButton,
       SingleGuillemetButton,
       LongDashButton,
-      NBSPDashButton
+      NBSPButton,
+      SoftHypenButton
     ]
   }
 })

--- a/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
+++ b/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
@@ -1,0 +1,84 @@
+import React from 'react'
+import { css } from 'glamor'
+
+const INVALID_TYPE = 'SPECIALCHARS_INVALID'
+const HYPEN_TYPE = 'SPECIALCHARS_HYPEN'
+const NBSP_TYPE = 'SPECIALCHARS_NBSP'
+
+const CHARS = [
+  ['\u2028', INVALID_TYPE],
+  ['\u00ad', HYPEN_TYPE],
+  ['\u00a0', NBSP_TYPE]
+]
+
+const styles = {
+  [INVALID_TYPE]: css({
+    ':before': {
+      color: 'red',
+      content: '•' // BULLET \u2022
+    }
+  }),
+  [HYPEN_TYPE]: css({
+    ':before': {
+      content: '‧' // HYPHENATION POINT \u2027
+    }
+  }),
+  [NBSP_TYPE]: css({
+    ':before': {
+      marginRight: '-0.25em',
+      content: '␣' // OPEN BOX \u2423
+    }
+  })
+}
+
+const createDecoration = (key, index, type) => ({
+  anchorKey: key,
+  anchorOffset: index,
+  focusKey: key,
+  focusOffset: index + 1,
+  marks: [{ type }]
+  // ToDo: After slate 0.39.0+ upgrade, use code below:
+  // anchor: {
+  //   key: key,
+  //   offset: index
+  // },
+  // focus: {
+  //   key: key,
+  //   offset: index + 1
+  // },
+  // mark: { type }
+})
+
+export default () => {
+  return {
+    renderMark ({mark, children, attributes}) {
+      if (styles[mark.type]) {
+        return (
+          <span {...attributes} {...styles[mark.type]}>
+            {children}
+          </span>
+        )
+      }
+    },
+    decorateNode (node) {
+      if (node.kind !== 'block') return
+      const texts = node.nodes.filter(child => child.kind === 'text')
+      if (!texts.size) return
+
+      const decorations = texts.reduce((decs, textNode) => {
+        const text = textNode.text
+        CHARS.forEach(([char, type]) => {
+          let index = text.indexOf(char)
+          while (index !== -1) {
+            decs.push(createDecoration(textNode.key, index, type))
+            index = text.indexOf(char, index + 1)
+          }
+        })
+
+        return decs
+      }, [])
+
+      return decorations
+    }
+  }
+}

--- a/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
+++ b/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
@@ -2,12 +2,12 @@ import React from 'react'
 import { css } from 'glamor'
 
 const INVALID_TYPE = 'SPECIALCHARS_INVALID'
-const HYPEN_TYPE = 'SPECIALCHARS_HYPEN'
+const HYPHEN_TYPE = 'SPECIALCHARS_HYPHEN'
 const NBSP_TYPE = 'SPECIALCHARS_NBSP'
 
 const CHARS = [
   ['\u2028', INVALID_TYPE],
-  ['\u00ad', HYPEN_TYPE],
+  ['\u00ad', HYPHEN_TYPE],
   ['\u00a0', NBSP_TYPE]
 ]
 
@@ -18,7 +18,7 @@ const styles = {
       content: '•' // BULLET \u2022
     }
   }),
-  [HYPEN_TYPE]: css({
+  [HYPHEN_TYPE]: css({
     ':before': {
       content: '‧' // HYPHENATION POINT \u2027
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "standardize": "standard --fix",
     "precommit": "npm run test:unit && lint-staged",
     "translations": "gsheets --key=1qPubCKz2YzbcFkRfF0MrgRqD0KLsgRPxoZfG5G3tHOA --title=live --pretty --out lib/translations.json",
-    "preinstall": "rm -rf .next && rm -rf node_modules/glamor && rm -rf node_modules/@project-r/styleguide",
+    "preinstall": "if [[ -z \"${TRAVIS}\" ]]; then rm -rf .next && rm -rf node_modules/glamor && rm -rf node_modules/@project-r/styleguide; fi",
     "link:sg": "rm -rf .next && npm link @project-r/styleguide && rm -rf node_modules/glamor && ln -s @project-r/styleguide/node_modules/glamor node_modules/glamor && echo '\n⚠️  Make sure to restart the next.js server. To unlink simply run npm install.\n'"
   },
   "repository": {


### PR DESCRIPTION
Makes some control characters that we're using or having trouble with (`\u2028`) visible.

<img width="892" alt="screen shot 2018-09-17 at 08 57 43" src="https://user-images.githubusercontent.com/410211/45609370-03e49300-ba58-11e8-9fc4-12b6c3018bef.png">

And add new soft hyphen button.

Not super happy with nbsp and hyphen visualisations, open for suggestions.