### PR TITLE
Link Repo/Table to cache query

### DIFF
--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -204,6 +204,15 @@ class RepoList extends Component {
     }, 500)
   }
 
+  componentWillUnmount () {
+    if (
+      this.debouncedRouting &&
+      this.debouncedRouting.cancel
+    ) {
+      this.debouncedRouting.cancel()
+    }
+  }
+
   render () {
     const {
       t,

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -230,7 +230,7 @@ class RepoList extends Component {
   render () {
     const {
       t,
-      data,
+      data = {},
       orderField,
       orderDirection,
       phase: filterPhase,
@@ -353,7 +353,9 @@ class RepoList extends Component {
           </thead>
           <tbody>
             {
-              !(data.loading || data.error) && data.repos.nodes.length === 0 && (
+              !(data.loading || data.error) &&
+              data.repos &&
+              data.repos.nodes.length === 0 && (
                 <Tr>
                   <Td colSpan='8'>
                     {t('repo/search/noResults')}
@@ -369,7 +371,7 @@ class RepoList extends Component {
                   </td>
                 </tr>
               )
-              : data.repos.nodes
+              : data.repos && data.repos.nodes
               .map(repo => ({
                 phase: phaseForRepo(repo),
                 repo
@@ -474,6 +476,7 @@ const RepoListWithQuery = compose(
   graphql(filterAndOrderRepos, {
     options: ({ search }) => ({
       fetchPolicy: 'cache-and-network',
+      skip: !process.browser,
       notifyOnNetworkStatusChange: true,
       variables: {
         search: search && search.length >= SEARCH_MIN_LENGTH

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -473,7 +473,7 @@ const RepoListWithQuery = compose(
   withT,
   graphql(filterAndOrderRepos, {
     options: ({ search }) => ({
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-and-network',
       notifyOnNetworkStatusChange: true,
       variables: {
         search: search && search.length >= SEARCH_MIN_LENGTH

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -68,7 +68,7 @@ mutation editRepoMeta(
 export const filterAndOrderRepos = gql`
 query repoListSearch($after: String, $search: String, $orderBy: RepoOrderBy) {
   repos: search(
-    first: 100,
+    first: 50,
     after: $after,
     search: $search,
     orderBy: $orderBy

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -473,6 +473,7 @@ const RepoListWithQuery = compose(
   withT,
   graphql(filterAndOrderRepos, {
     options: ({ search }) => ({
+      fetchPolicy: 'network-only',
       notifyOnNetworkStatusChange: true,
       variables: {
         search: search && search.length >= SEARCH_MIN_LENGTH

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -90,6 +90,9 @@ query repoListSearch($after: String, $search: String, $orderBy: RepoOrderBy) {
         id
         date
         message
+        author {
+          name
+        }
         document {
           id
           meta {
@@ -376,8 +379,17 @@ class RepoList extends Component {
               .map(({repo, phase}) => {
                 const {
                   id,
-                  meta: {creationDeadline, productionDeadline, publishDate, briefingUrl},
-                  latestCommit: {date, document: {meta}}
+                  meta: {
+                    creationDeadline,
+                    productionDeadline,
+                    publishDate,
+                    briefingUrl
+                  },
+                  latestCommit: {
+                    date,
+                    author: { name: authorName },
+                    document: { meta }
+                  }
                 } = repo
 
                 return (
@@ -395,7 +407,10 @@ class RepoList extends Component {
                       renderMdast(meta.credits.filter(link.matchMdast), creditSchema),
                       () => ', '
                     )}</Td>
-                    <TdNum>{displayDateTime(date)}</TdNum>
+                    <TdNum>
+                      <Label>{authorName}</Label><br />
+                      {displayDateTime(date)}
+                    </TdNum>
                     <TdNum>
                       <EditMetaDate
                         value={creationDeadline}

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -67,7 +67,7 @@ mutation editRepoMeta(
 
 export const filterAndOrderRepos = gql`
 query repoListSearch($after: String, $search: String, $orderBy: RepoOrderBy) {
-  repos: search(
+  repos: reposSearch(
     first: 50,
     after: $after,
     search: $search,

--- a/components/editor/modules/meta/RepoSelect.js
+++ b/components/editor/modules/meta/RepoSelect.js
@@ -30,7 +30,7 @@ const styles = {
   })
 }
 
-export default ({ label, value, onChange }) => {
+export default ({ label, template, value, onChange }) => {
   const onRefChange = item => {
     onChange(
       undefined,
@@ -58,8 +58,10 @@ export default ({ label, value, onChange }) => {
       </div>
     )
   }
+
   return <RepoSearch
     label={label}
+    template={template}
     onChange={onRefChange}
   />
 }

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -138,6 +138,7 @@ const MetaData = ({value, editor, mdastSchema, contextMeta, series, additionalFi
                 <RepoSelect key={customField.key}
                   label={label}
                   value={value}
+                  template={customField.key}
                   onChange={customField.key === 'format'
                     ? (_, __, item) => {
                       editor.change(change => {

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -7,8 +7,8 @@ import debounce from 'lodash.debounce'
 import { GITHUB_ORG, REPO_PREFIX } from '../../../lib/settings'
 
 export const filterRepos = gql`
-query searchRepo($after: String, $search: String) {
-  repos: search(first: 10, after: $after, search: $search) {
+query searchRepo($after: String, $search: String, $template: String) {
+  repos: search(first: 10, after: $after, search: $search, template: $template) {
     totalCount
     pageInfo {
       endCursor
@@ -47,7 +47,9 @@ query searchRepo($after: String, $search: String) {
 
 const ConnectedAutoComplete = graphql(filterRepos, {
   skip: props => !props.filter,
-  options: ({ search }) => ({ variables: { search: search } }),
+  options: ({ search, template }) => ({
+    variables: { search: search, template: template }
+  }),
   props: (props) => {
     if (props.data.loading) return { data: props.data, items: [] }
     const { data: { repos: { nodes = [] } = {} } } = props
@@ -136,6 +138,7 @@ export default class RepoSearch extends Component {
         filter={filter}
         value={value}
         search={search}
+        template={this.props.template}
         items={[]}
         onChange={this.changeHandler}
         onFilterChange={this.filterChangeHandler}

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -8,7 +8,7 @@ import { GITHUB_ORG, REPO_PREFIX } from '../../../lib/settings'
 
 export const filterRepos = gql`
 query searchRepo($after: String, $search: String, $template: String) {
-  repos: search(first: 10, after: $after, search: $search, template: $template) {
+  repos: reposSearch(first: 10, after: $after, search: $search, template: $template) {
     totalCount
     pageInfo {
       endCursor

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -48,6 +48,7 @@ query searchRepo($after: String, $search: String, $template: String) {
 const ConnectedAutoComplete = graphql(filterRepos, {
   skip: props => !props.filter,
   options: ({ search, template }) => ({
+    fetchPolicy: 'network-only',
     variables: { search: search, template: template }
   }),
   props: (props) => {

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -8,7 +8,7 @@ import { GITHUB_ORG, REPO_PREFIX } from '../../../lib/settings'
 
 export const filterRepos = gql`
 query searchRepo($after: String, $search: String) {
-  repos(first: 10, after: $after, search: $search) {
+  repos: search(first: 10, after: $after, search: $search) {
     totalCount
     pageInfo {
       endCursor


### PR DESCRIPTION
This Pull Request rewires `repos` queries to `search` query. `search` query provides same information but relays on cached information instead of hitting GitHub API. It requires https://github.com/orbiting/backends/pull/98 to be deployed.

It furthermore limits articles to it's corresponding template when [linking formats, discussions or dossiers in meta section](https://github.com/orbiting/publikator-frontend/pull/169/files#diff-127bb7b4ddb6e24f58fac0c8327de04eR141) instead of returning all matching articles.
It allows to limit query to a template like format or discussion.

Then it displays the [author's name of the latest commit in the repo table](https://github.com/orbiting/publikator-frontend/pull/169/files#diff-7d4f1f98e1469a709374e34ec16d32daR411) right above the date of the last commit.

<img width="420" alt="displays author of latest commit" src="https://user-images.githubusercontent.com/331800/45883116-6b7c4480-bdb0-11e8-828b-e4d30d4a9ecc.png">

To increase response time, in the repo table only 50 records are fetched instead of 100. Due to faster `search` API response this could be just enough.

[`fetchPolicy` on repo table is set to `cache-and-network`](https://github.com/orbiting/publikator-frontend/pull/169/files#diff-7d4f1f98e1469a709374e34ec16d32daR476) which will display an available cached version but also queries again in background. This helps to see less (or no) stale data when navigating "back" onto the overview. (This might collide with pagination.)

To minimize an observed side effect of having used stale data when copying article data (via "Artikel suchen"), [`fetchPolicy` in `RepoSearch` is set to `network-only`](https://github.com/orbiting/publikator-frontend/pull/169/files#diff-84c7309d2f0fa1d32f09dcff1c84cc32R51) to guarantee it provides always latest data from API.