### PR TITLE
decorate combining-diaeresis chars

### DIFF
--- a/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
+++ b/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
@@ -7,6 +7,7 @@ const NBSP_TYPE = 'SPECIALCHARS_NBSP'
 
 const CHARS = [
   ['\u2028', INVALID_TYPE],
+  ['\u0308', INVALID_TYPE],
   ['\u00ad', HYPHEN_TYPE],
   ['\u00a0', NBSP_TYPE]
 ]


### PR DESCRIPTION
[combined diaeresis](https://www.fileformat.info/info/unicode/char/0308/index.htm) lead to ugly results in some browsers (namely our app). This PR decorates them and allows the production team to fix them before publishing.

![screenshot from 2018-10-08 18-05-41](https://user-images.githubusercontent.com/3500621/46620365-cccc4380-cb24-11e8-829b-27ba9a4df4bd.png)
