### PR TITLE
feat(DynamicComponent): provide gql & graphl ql as external dependency

### DIFF
--- a/components/Templates/index.js
+++ b/components/Templates/index.js
@@ -10,17 +10,19 @@ import createDossierSchema from '@project-r/styleguide/lib/templates/Dossier'
 
 import { t } from '../../lib/withT'
 
+import dynamicComponentRequire from '../editor/modules/dynamiccomponent/require'
+
 const schemas = {
   // first is default schema for the editor
   // - for Project R this should be the newsletter
   newsletter: newsletterSchema,
   editorialNewsletter: editorialNewsletterSchema(),
   neutrum: neutrumSchema,
-  article: createArticleSchema({t}),
-  front: createFrontSchema({t}),
-  format: createFormatSchema({t}),
-  discussion: createDiscussionSchema({t}),
-  dossier: createDossierSchema({t})
+  article: createArticleSchema({ t, dynamicComponentRequire }),
+  front: createFrontSchema({ t }),
+  format: createFormatSchema({ t, dynamicComponentRequire }),
+  discussion: createDiscussionSchema({ t, dynamicComponentRequire }),
+  dossier: createDossierSchema({ t, dynamicComponentRequire })
 }
 
 export const getSchema = template => {

--- a/components/editor/modules/dynamiccomponent/index.js
+++ b/components/editor/modules/dynamiccomponent/index.js
@@ -10,7 +10,9 @@ import EditOverlay from './EditOverlay'
 
 import { SG_DYNAMIC_COMPONENT_BASE_URLS } from '../../../../lib/settings'
 
-export default ({rule, subModules, TYPE}) => {
+import dynamicComponentRequire from './require'
+
+export default ({ rule, subModules, TYPE }) => {
   const {
     identifier = 'DYNAMIC_COMPONENT'
   } = rule.editorOptions || {}
@@ -87,6 +89,7 @@ export default ({rule, subModules, TYPE}) => {
           const component = <DynamicComponent
             showException
             key={JSON.stringify(data)}
+            require={dynamicComponentRequire}
             {...data} />
           const preview = cloneElement(component, {
             raw: true

--- a/components/editor/modules/dynamiccomponent/require.js
+++ b/components/editor/modules/dynamiccomponent/require.js
@@ -1,0 +1,16 @@
+import { createRequire } from '@project-r/styleguide/lib/components/DynamicComponent'
+
+/*
+ * import all react-apollo and graphql-tag functions
+ * for dynamic components
+ */
+
+/* eslint-disable */
+import * as reactApollo from 'react-apollo'
+import * as graphqlTag from 'graphql-tag'
+/* eslint-enable */
+
+export default createRequire().alias({
+  'react-apollo': reactApollo,
+  'graphql-tag': graphqlTag
+})


### PR DESCRIPTION
Enabled dynamic components to use GraphQL.

Make sure to configure `{"autoHtml": false}` to not auto generate ssr html with personal data of an editor.

<img width="1328" alt="screenshot 2019-02-06 at 19 39 30" src="https://user-images.githubusercontent.com/410211/52365168-3282fa80-2a47-11e9-9480-110b12f2c76f.png">
