### PR TITLE
Archive repositories

### DIFF
--- a/components/Publication/PublishForm.js
+++ b/components/Publication/PublishForm.js
@@ -11,6 +11,7 @@ import { intersperse } from '../../lib/utils/helpers'
 import withT from '../../lib/withT'
 import { Link, Router } from '../../lib/routes'
 import { swissTime } from '../../lib/utils/format'
+
 import {
   Loader,
   InlineSpinner,
@@ -32,6 +33,7 @@ import { getRepoWithPublications } from './Current'
 import { renderMdast } from 'mdast-react-render'
 
 import { getSchema } from '../../components/Templates'
+import RepoArchivedBanner from '../../components/Repo/ArchivedBanner'
 
 export const publish = gql`
 mutation publish(
@@ -63,6 +65,7 @@ export const getRepoWithCommit = gql`
   query repoWithCommit($repoId: ID!, $commitId: ID!) {
     repo(id: $repoId) {
       id
+      isArchived
       meta {
         publishDate
       }
@@ -163,7 +166,11 @@ class PublishForm extends Component {
     return (
       <div>
         <Loader loading={loading} error={error} render={() => {
-          const { commit, commit: { document: { meta } } } = repo
+          const { isArchived, commit, commit: { document: { meta } } } = repo
+
+          if (isArchived) {
+            return <RepoArchivedBanner />
+          }
 
           const schema = getSchema(meta.template)
 

--- a/components/Repo/Archive.js
+++ b/components/Repo/Archive.js
@@ -4,6 +4,7 @@ import gql from 'graphql-tag'
 import Router, { withRouter } from 'next/router'
 
 import withT from '../../lib/withT'
+import { errorToString } from '../../lib/utils/errors'
 
 import { A } from '@project-r/styleguide'
 
@@ -29,11 +30,7 @@ const RepoArchive = ({ repoId, t }) => {
                 Router.pushRoute('index')
               })
               .catch((error) => {
-                if (error.graphQLErrors) {
-                  window.alert(error.graphQLErrors.map(({ message }) => message).join('\n'))
-                } else {
-                  window.alert(error)
-                }
+                window.alert(errorToString(error))
               })
           }
         }}>

--- a/components/Repo/Archive.js
+++ b/components/Repo/Archive.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { Mutation, compose } from 'react-apollo'
+import gql from 'graphql-tag'
+import Router, { withRouter } from 'next/router'
+
+import withT from '../../lib/withT'
+
+import { A } from '@project-r/styleguide'
+
+export const ARCHIVE_REPO = gql`
+  mutation repoArchive($repoId: ID!) {
+    archive(repoIds: [$repoId]) {
+      nodes {
+        id
+      }
+    }
+  }
+`
+
+const RepoArchive = ({ repoId, t }) => {
+  return (
+    <Mutation mutation={ARCHIVE_REPO} variables={{ repoId }}>
+      {archiveRepo => (
+        <A href='#' onClick={e => {
+          e.preventDefault()
+          if (window.confirm(t('repo/archive/confirm', { repoId }))) {
+            archiveRepo()
+              .then(() => {
+                Router.pushRoute('index')
+              })
+              .catch((error) => {
+                if (error.graphQLErrors) {
+                  window.alert(error.graphQLErrors.map(({ message }) => message).join('\n'))
+                } else {
+                  window.alert(error)
+                }
+              })
+          }
+        }}>
+          {t('repo/archive/button')}
+        </A>
+      )}
+    </Mutation>
+  )
+}
+
+export default compose(withT, withRouter)(RepoArchive)

--- a/components/Repo/ArchivedBanner.js
+++ b/components/Repo/ArchivedBanner.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { compose } from 'react-apollo'
+import { css } from 'glamor'
+
+import withT from '../../lib/withT'
+
+import { Interaction, colors } from '@project-r/styleguide'
+
+const styles = {
+  container: css({
+    backgroundColor: colors.social,
+    padding: '12px 24px',
+    marginBottom: '12px'
+  }),
+  notice: css({
+    color: 'white'
+  })
+}
+
+const RepoArchivedBanner = ({ t }) => {
+  return (
+    <div {...styles.container}>
+      <Interaction.H3 {...styles.notice}>{t('repo/archived/notice')}</Interaction.H3>
+    </div>
+  )
+}
+
+export default compose(withT)(RepoArchivedBanner)

--- a/lib/graphql/fragments.js
+++ b/lib/graphql/fragments.js
@@ -70,6 +70,7 @@ export const MilestoneWithCommit = gql`
 export const EditPageRepo = gql`
   fragment EditPageRepo on Repo {
     id
+    isArchived
     meta {
       publishDate
     }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-07-17T10:13:16.747Z",
+  "updated": "2019-04-15T11:24:22.824Z",
   "title": "live",
   "data": [
     {
@@ -201,6 +201,14 @@
     {
       "key": "repo/table/col/productionDeadline",
       "value": "Produktions-Deadline"
+    },
+    {
+      "key": "repo/archive/confirm",
+      "value": "\"{repoId}\" tatsächlich archivieren?"
+    },
+    {
+      "key": "repo/archive/button",
+      "value": "Artikel archivieren"
     },
     {
       "key": "baseCommit/title",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-04-15T11:24:22.824Z",
+  "updated": "2019-04-15T15:07:33.657Z",
   "title": "live",
   "data": [
     {
@@ -204,11 +204,15 @@
     },
     {
       "key": "repo/archive/confirm",
-      "value": "\"{repoId}\" tatsächlich archivieren?"
+      "value": "Artikel tatsächlich archivieren?"
     },
     {
       "key": "repo/archive/button",
       "value": "Artikel archivieren"
+    },
+    {
+      "key": "repo/archived/notice",
+      "value": "Artikel wurde archiviert und kann nicht bearbeitet oder veröffentlicht werden."
     },
     {
       "key": "baseCommit/title",

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -10,6 +10,7 @@ import withAuthorization from '../../components/Auth/withAuthorization'
 import Frame from '../../components/Frame'
 import { HEADER_HEIGHT } from '../../components/Frame/constants'
 import RepoNav from '../../components/Repo/Nav'
+import RepoArchivedBanner from '../../components/Repo/ArchivedBanner'
 
 import Editor from '../../components/editor'
 import EditorUI from '../../components/editor/UI'
@@ -654,7 +655,8 @@ export class EditorPage extends Component {
       ...warnings.filter(Boolean).map((m, i) => <Warning key={`warning-${i}`} message={m} />),
       !showLoading && repo && (
         <BranchingNotice key='branching-notice' repoId={repo.id} currentCommitId={commitId} />
-      )
+      ),
+      !showLoading && repo && repo.isArchived && <RepoArchivedBanner />
     ].filter(Boolean)
 
     return (

--- a/pages/repo/tree.js
+++ b/pages/repo/tree.js
@@ -13,6 +13,7 @@ import Tree from '../../components/Tree'
 import Frame from '../../components/Frame'
 import RepoNav from '../../components/Repo/Nav'
 import RepoArchive from '../../components/Repo/Archive'
+import RepoArchivedBanner from '../../components/Repo/ArchivedBanner'
 import { NarrowContainer, A, InlineSpinner, Interaction } from '@project-r/styleguide'
 import { getKeys as getLocalStorageKeys } from '../../lib/utils/localStorage'
 import * as fragments from '../../lib/graphql/fragments'
@@ -29,6 +30,7 @@ export const getRepoHistory = gql`
   ) {
     repo(id: $repoId) {
       id
+      isArchived
       commits(first: $first, after: $after) {
         pageInfo {
           hasNextPage
@@ -51,6 +53,7 @@ const treeRepoSubscription = gql`
   subscription onRepoUpdate($repoId: ID!) {
     repoUpdate(repoId: $repoId) {
       id
+      isArchived
       commits (first: 1){
         nodes {
           ...SimpleCommit
@@ -66,6 +69,9 @@ const treeRepoSubscription = gql`
 `
 
 const styles = {
+  publishContainer: css({
+    marginTop: '24px'
+  }),
   loadMoreButton: css({
     cursor: 'pointer'
   }),
@@ -170,10 +176,15 @@ class EditorPage extends Component {
         <Frame.Body raw>
           <Loader loading={loading && !repo} error={error} render={() => (
             <Fragment>
-              <NarrowContainer style={{ paddingTop: '1em' }}>
-                <CurrentPublications repoId={repoId} />
-                <RepoArchive repoId={repoId} />
-              </NarrowContainer>
+              { repo.isArchived
+                ? <RepoArchivedBanner />
+                : (
+                  <NarrowContainer {...styles.publishContainer}>
+                    <CurrentPublications repoId={repoId} />
+                    <RepoArchive repoId={repoId} />
+                  </NarrowContainer>
+                )
+              }
               <Tree
                 commits={commits}
                 localStorageCommitIds={localStorageCommitIds}

--- a/pages/repo/tree.js
+++ b/pages/repo/tree.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { withRouter } from 'next/router'
 import { css } from 'glamor'
 import { graphql, compose } from 'react-apollo'
@@ -12,6 +12,7 @@ import Loader from '../../components/Loader'
 import Tree from '../../components/Tree'
 import Frame from '../../components/Frame'
 import RepoNav from '../../components/Repo/Nav'
+import RepoArchive from '../../components/Repo/Archive'
 import { NarrowContainer, A, InlineSpinner, Interaction } from '@project-r/styleguide'
 import { getKeys as getLocalStorageKeys } from '../../lib/utils/localStorage'
 import * as fragments from '../../lib/graphql/fragments'
@@ -168,10 +169,10 @@ class EditorPage extends Component {
         </Frame.Header>
         <Frame.Body raw>
           <Loader loading={loading && !repo} error={error} render={() => (
-            <div>
-              <br />
-              <NarrowContainer>
+            <Fragment>
+              <NarrowContainer style={{ paddingTop: '1em' }}>
                 <CurrentPublications repoId={repoId} />
+                <RepoArchive repoId={repoId} />
               </NarrowContainer>
               <Tree
                 commits={commits}
@@ -190,7 +191,7 @@ class EditorPage extends Component {
                   }
                 </Interaction.P>
               }
-            </div>
+            </Fragment>
           )} />
         </Frame.Body>
       </Frame>


### PR DESCRIPTION
Depends on https://github.com/orbiting/backends/pull/229

Feature enables archiving repositories.

Link at the top on tree view will ask for confirmation, send a mutation and redirect to overview page.

<img width="811" alt="Bildschirmfoto 2019-04-15 um 14 13 37" src="https://user-images.githubusercontent.com/331800/56131955-22c4ec80-5f89-11e9-986d-e8606fc316a9.png">

<img width="463" alt="Bildschirmfoto 2019-04-15 um 14 12 42" src="https://user-images.githubusercontent.com/331800/56131964-26587380-5f89-11e9-83a9-7ad84a3271b1.png">

It will display errors from mutation, too:

<img width="462" alt="Bildschirmfoto 2019-04-15 um 14 12 49" src="https://user-images.githubusercontent.com/331800/56131994-34a68f80-5f89-11e9-92b7-01526093a060.png">

It will also render a banner if an archived repo is opened and omit publish form.

<img width="830" alt="Bildschirmfoto 2019-04-15 um 17 09 26" src="https://user-images.githubusercontent.com/331800/56145097-e652ba00-5fa3-11e9-9929-bc497752e7d7.png">