### PR TITLE
Dark mode for photo series

### DIFF
--- a/components/IFrame/index.js
+++ b/components/IFrame/index.js
@@ -3,6 +3,7 @@ import { styleSheet } from 'glamor'
 import Frame from 'react-frame-component'
 import PropTypes from 'prop-types'
 import createDebug from 'debug'
+import { ColorContext, colors } from '@project-r/styleguide'
 
 const debug = createDebug('publikator:iframe')
 
@@ -43,7 +44,7 @@ class IFrame extends Component {
     }
   }
   render() {
-    const { size, style, children } = this.props
+    const { size, style, children, dark } = this.props
     const { width, css } = this.state
 
     const scale = width ? Math.min(1, width / size.width) : 1
@@ -68,7 +69,9 @@ class IFrame extends Component {
               height: size.height
             }}
           >
-            {children}
+            <ColorContext.Provider value={dark && colors.negative}>
+              {children}
+            </ColorContext.Provider>
           </Frame>
         </div>
       </div>

--- a/components/Publication/PublishForm.js
+++ b/components/Publication/PublishForm.js
@@ -557,6 +557,10 @@ class PublishForm extends Component {
                     backgroundColor: '#eee',
                     width: size.width + PADDING_X * 2
                   }}
+                  dark={
+                    commit.document.content &&
+                    commit.document.content.meta.darkMode
+                  }
                 >
                   {renderMdast(
                     {

--- a/components/editor/modules/meta/DarkModeForm.js
+++ b/components/editor/modules/meta/DarkModeForm.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Checkbox } from '@project-r/styleguide'
+import withT from '../../../../lib/withT'
+
+export const DARK_MODE_KEY = 'darkMode'
+
+export default withT(({ t, data, onChange }) => {
+  return (
+    <div style={{ marginTop: 10 }}>
+      <Checkbox checked={data.get(DARK_MODE_KEY)} onChange={onChange}>
+        Dark mode
+      </Checkbox>
+    </div>
+  )
+})

--- a/components/editor/modules/meta/DarkModeForm.js
+++ b/components/editor/modules/meta/DarkModeForm.js
@@ -8,7 +8,7 @@ export default withT(({ t, data, onChange }) => {
   return (
     <div style={{ marginTop: 10 }}>
       <Checkbox checked={data.get(DARK_MODE_KEY)} onChange={onChange}>
-        Dark mode
+        {t('metaData/darkMode')}
       </Checkbox>
     </div>
   )

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -24,6 +24,7 @@ import RepoSelect from './RepoSelect'
 import SeriesForm from './SeriesForm'
 import AudioForm from './AudioForm'
 import UIForm from '../../UIForm'
+import DarkModeForm, { DARK_MODE_KEY } from './DarkModeForm'
 
 const styles = {
   container: css({
@@ -49,6 +50,7 @@ const MetaData = ({
   mdastSchema,
   contextMeta,
   series,
+  darkMode,
   additionalFields = [],
   customFields = [],
   teaser: Teaser,
@@ -293,6 +295,12 @@ const MetaData = ({
             <br />
             <Teaser {...dataAsJs} credits={undefined} />
           </div>
+        )}
+        {!!darkMode && (
+          <DarkModeForm
+            data={node.data}
+            onChange={onInputChange(DARK_MODE_KEY)}
+          />
         )}
         <br />
         <br />

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-11-13T13:46:44.798Z",
+  "updated": "2020-01-08T15:50:32.259Z",
   "title": "live",
   "data": [
     {
@@ -439,6 +439,10 @@
       "value": "Bildbeschrieb"
     },
     {
+      "key": "metaData/field/formats",
+      "value": "Formate"
+    },
+    {
       "key": "metaData/field/label",
       "value": "Label"
     },
@@ -591,6 +595,70 @@
       "value": "Schriftgrösse"
     },
     {
+      "key": "metaData/paynotes/add",
+      "value": "Add custom paynotes"
+    },
+    {
+      "key": "metaData/paynotes/title",
+      "value": "Custom paynotes"
+    },
+    {
+      "key": "metaData/paynotes/before",
+      "value": "Paynote {index} - before"
+    },
+    {
+      "key": "metaData/paynotes/after",
+      "value": "Paynote {index} - after"
+    },
+    {
+      "key": "metaData/paynotes/new",
+      "value": "new paynote"
+    },
+    {
+      "key": "metaData/paynotes/help",
+      "value": "Render members count with <b>{count}</b> and bold text with <b>&lt;b&gt;bold tags&lt;/b&gt;</b>."
+    },
+    {
+      "key": "metaData/paynote/form/cta/label",
+      "value": "Call to action"
+    },
+    {
+      "key": "metaData/paynote/form/cta/0",
+      "value": "trial form"
+    },
+    {
+      "key": "metaData/paynote/form/cta/1",
+      "value": "button"
+    },
+    {
+      "key": "metaData/paynote/form/cta/2",
+      "value": "none"
+    },
+    {
+      "key": "metaData/paynote/form/trynote",
+      "value": "Try Republik"
+    },
+    {
+      "key": "metaData/paynote/form/buynote",
+      "value": "Buy Republik"
+    },
+    {
+      "key": "metaData/paynote/form/title",
+      "value": "Title"
+    },
+    {
+      "key": "metaData/paynote/form/body",
+      "value": "Body"
+    },
+    {
+      "key": "metaData/paynote/form/button/label",
+      "value": "Button label"
+    },
+    {
+      "key": "metaData/paynote/form/button/link",
+      "value": "Button link\n"
+    },
+    {
       "key": "metaData/field/url",
       "value": "URL"
     },
@@ -625,6 +693,10 @@
     {
       "key": "metaData/field/gallery",
       "value": "Bilder als Galerie"
+    },
+    {
+      "key": "metaData/darkMode",
+      "value": "Dark Mode"
     },
     {
       "key": "uncommittedChanges/unlock/confirm/1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1286,9 +1286,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-8.20.0.tgz",
-      "integrity": "sha512-uV9Q4XnFLUD5GcVqDgawDTdJhf7liuEcu8h2QtkKRCrpq2wzbxQN8ffOz3quaZorkFwBF46UQsgHEB3s0u/FMQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-8.21.0.tgz",
+      "integrity": "sha512-Nt5qEfBijpwXGby1A08bWwdrehX5+t/ZMh9Tt0LP4pGVi41lSltCZRmNYDWSeiIuvIN1G5fMBniCiAmX6ehzaw==",
       "requires": {
         "react-icons": "^2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.4",
-    "@project-r/styleguide": "^8.20.0",
+    "@project-r/styleguide": "^8.21.0",
     "@project-r/template-newsletter": "^1.5.0",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -41,10 +41,11 @@ import { getSchema } from '../../components/Templates'
 import { API_UNCOMMITTED_CHANGES_URL } from '../../lib/settings'
 import * as fragments from '../../lib/graphql/fragments'
 
-import { colors } from '@project-r/styleguide'
+import { ColorContext, colors } from '@project-r/styleguide'
 import SettingsIcon from 'react-icons/lib/fa/cogs'
 
 import createDebug from 'debug'
+import { DARK_MODE_KEY } from '../../components/editor/modules/meta/DarkModeForm'
 
 const commitMutation = gql`
   mutation commit(
@@ -666,6 +667,7 @@ export class EditorPage extends Component {
     const isNew = commitId === 'new'
     const error = data.error || this.state.error
     const showLoading = committing || loading || (!schema && !error)
+    const dark = editorState && editorState.document.data.get(DARK_MODE_KEY)
 
     const sidebarPrependChildren = [
       ...warnings
@@ -763,15 +765,17 @@ export class EditorPage extends Component {
                     }
                   />
                 )}
-                <Editor
-                  ref={this.editorRef}
-                  schema={schema}
-                  meta={repo ? repo.meta : {}}
-                  value={editorState}
-                  onChange={this.changeHandler}
-                  onDocumentChange={this.documentChangeHandler}
-                  readOnly={readOnly}
-                />
+                <ColorContext.Provider value={dark && colors.negative}>
+                  <Editor
+                    ref={this.editorRef}
+                    schema={schema}
+                    meta={repo ? repo.meta : {}}
+                    value={editorState}
+                    onChange={this.changeHandler}
+                    onDocumentChange={this.documentChangeHandler}
+                    readOnly={readOnly}
+                  />
+                </ColorContext.Provider>
               </div>
             )}
           />


### PR DESCRIPTION
- add dark mode checkbox in article metadata form
- support dark mode in preview

<img width="656" alt="Screenshot 2020-01-08 at 16 16 38" src="https://user-images.githubusercontent.com/3907984/71993853-15970e80-3238-11ea-840c-cabe7a367550.png">

![Screenshot 2020-01-08 at 16 32 13](https://user-images.githubusercontent.com/3907984/71993866-1a5bc280-3238-11ea-9a90-6747f5acf6b5.png)
