### PR TITLE
WIP Dark mode for related articles

### DIFF
--- a/components/editor/modules/teaser/index.js
+++ b/components/editor/modules/teaser/index.js
@@ -12,8 +12,6 @@ import { TeaserButton, TeaserInlineUI, TeaserForm } from './ui'
 export const getData = data => ({
   url: null,
   textPosition: 'topleft',
-  color: '#000',
-  bgColor: '#fff',
   center: false,
   image: null,
   byline: null,

--- a/components/editor/modules/teaser/serializer.js
+++ b/components/editor/modules/teaser/serializer.js
@@ -105,8 +105,7 @@ const fromMdast = ({ TYPE, subModules, rule }) => (
       const articleTilePatches =
         data.teaserType === 'articleTile' && node.type === 'FRONTSUBJECT'
           ? {
-              columns: 3,
-              color: '#000'
+              columns: 3
             }
           : undefined
       return {

--- a/components/editor/modules/teaser/ui.js
+++ b/components/editor/modules/teaser/ui.js
@@ -161,9 +161,7 @@ const cloneWithRepoData = options => (node, repoData) => {
       }),
       Block.create({
         type: subjectModule.TYPE,
-        data: isArticleTile
-          ? data.set('columns', 3).set('color', '#000')
-          : data,
+        data: isArticleTile ? data.set('columns', 3) : data,
         nodes: meta.subject ? [Text.create(meta.subject)] : []
       }),
       Block.create({


### PR DESCRIPTION
- remove default black and white scheme for teasers (if no color is set the default colors are handled by the styleguide)

**Needs to be tested for teasers with user set colors**

![Screenshot 2020-01-20 at 17 53 33](https://user-images.githubusercontent.com/3907984/72744792-8cc09100-3bae-11ea-8251-7c811bab1bc2.png)
