### PR TITLE
fix: Recognize "autoSlug" in repo URL when other search parameters are present, too

### DIFF
--- a/components/editor/utils/github.js
+++ b/components/editor/utils/github.js
@@ -42,7 +42,7 @@ export const RepoLink = ({
   if (!info) {
     return invalid(info)
   }
-  if (autoSlug && info.query !== 'autoSlug') {
+  if (autoSlug && !info.query.match(/(^|&)autoSlug([=&#].+)?$/)) {
     return invalid(info)
   }
   return (


### PR DESCRIPTION
Regular Expression `/(^|&)autoSlug([=&#].+)?$/`

a) either begin with beginning of string or `&`
b) match `autoSlug`
c) either end after `autoSlug` or continue with `=`, `&` or `#` and some chars

Matching:
- autoSlug
- autoSlug=1&audio=1
- autoSlug&audio=1
- autoSlug#banana
- foobar=1&autoSlug&audio=1

Not matching:
- foobar=autoSlug
- foobar=autoSlug&audio=1
- autoSlugTest
- autoSlugTest=1
- autoSlug&

Depends on https://github.com/orbiting/backends/pull/403