### PR TITLE
fix(specialchars): Render invisible chars blueish to make them distiguishable from visible ones

### DIFF
--- a/components/editor/modules/specialchars/index.js
+++ b/components/editor/modules/specialchars/index.js
@@ -101,7 +101,7 @@ const NBSPButton = ({ value, onChange }) => {
       data-visible
       onMouseDown={nbspClickHandler(value, onChange)}
     >
-      Dauerleerzeichen (␣)
+      Dauerleerzeichen (<span style={{ color: '#1E90FF' }}>␣</span>)
     </span>
   )
 }
@@ -121,7 +121,7 @@ const SoftHyphenButton = ({ value, onChange }) => {
       data-visible
       onMouseDown={softHyphenClickHandler(value, onChange)}
     >
-      Weiches Trennzeichen (‧)
+      Weiches Trennzeichen (<span style={{ color: '#1E90FF' }}>‧</span>)
     </span>
   )
 }

--- a/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
+++ b/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
@@ -21,11 +21,13 @@ const styles = {
   }),
   [HYPHEN_TYPE]: css({
     ':before': {
+      color: '#1E90FF',
       content: '‧' // HYPHENATION POINT \u2027
     }
   }),
   [NBSP_TYPE]: css({
     ':before': {
+      color: '#1E90FF',
       marginRight: '-0.25em',
       content: '␣' // OPEN BOX \u2423
     }

--- a/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
+++ b/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
@@ -9,7 +9,7 @@ const CHARS = [
   ['\u2028', INVALID_TYPE],
   ['\u0308', INVALID_TYPE],
   ['\u2022', INVALID_TYPE],
-  ['\u2423', INVALID_TYPE],
+  ['\u2027', INVALID_TYPE],
   ['\u2423', INVALID_TYPE],
   ['\u00ad', HYPHEN_TYPE],
   ['\u00a0', NBSP_TYPE]

--- a/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
+++ b/components/editor/modules/specialchars/invisibleDecoratorPlugin.js
@@ -8,6 +8,9 @@ const NBSP_TYPE = 'SPECIALCHARS_NBSP'
 const CHARS = [
   ['\u2028', INVALID_TYPE],
   ['\u0308', INVALID_TYPE],
+  ['\u2022', INVALID_TYPE],
+  ['\u2423', INVALID_TYPE],
+  ['\u2423', INVALID_TYPE],
   ['\u00ad', HYPHEN_TYPE],
   ['\u00a0', NBSP_TYPE]
 ]


### PR DESCRIPTION
This Pull Request will render invisible chars (hyphen, no-break space) in a blueish color. It should help distinguish invisible chars from chars which will be visible in published documents.

**Samples**

*Paragraph*

<img width="427" alt="Bildschirmfoto 2020-05-16 um 12 57 09" src="https://user-images.githubusercontent.com/331800/82118415-9f6f5f00-9777-11ea-8ffc-eec16bda4c13.png">
<img width="425" alt="Bildschirmfoto 2020-05-16 um 12 56 57" src="https://user-images.githubusercontent.com/331800/82118416-a0a08c00-9777-11ea-8e73-4a7ce845795b.png">

*Block quote*

<img width="682" alt="Bildschirmfoto 2020-05-16 um 13 05 16" src="https://user-images.githubusercontent.com/331800/82118428-abf3b780-9777-11ea-936a-fe08ff7f8701.png">
<img width="680" alt="Bildschirmfoto 2020-05-16 um 13 05 02" src="https://user-images.githubusercontent.com/331800/82118429-ad24e480-9777-11ea-909b-9742ed203c05.png">

*Title and lead*

<img width="678" alt="Bildschirmfoto 2020-05-16 um 13 06 46" src="https://user-images.githubusercontent.com/331800/82118431-b6ae4c80-9777-11ea-8e63-58bfd1715d0b.png">

<img width="672" alt="Bildschirmfoto 2020-05-16 um 13 07 35" src="https://user-images.githubusercontent.com/331800/82118435-b910a680-9777-11ea-8950-7b0fddeec46b.png">

*Teaser*

<img width="356" alt="Bildschirmfoto 2020-05-16 um 13 07 52" src="https://user-images.githubusercontent.com/331800/82118436-bb730080-9777-11ea-8c1c-63d45445384f.png">
