### PR TITLE
feat(FrontImage): maxWidth and textPosition underneath

### DIFF
--- a/components/editor/modules/teaser/ui.js
+++ b/components/editor/modules/teaser/ui.js
@@ -43,7 +43,8 @@ const textPositions = [
   { value: 'topleft', text: 'Top Left' },
   { value: 'topright', text: 'Top Right' },
   { value: 'bottomleft', text: 'Bottom Left' },
-  { value: 'bottomright', text: 'Bottom Right' }
+  { value: 'bottomright', text: 'Bottom Right' },
+  { value: 'underneath', text: 'Underneath' }
 ]
 
 const titleSizes = [
@@ -338,6 +339,15 @@ const Form = withT(({ node, onChange, onTypeChange, options, t }) => {
           label='Bildcredit'
           value={node.data.get('byline') || ''}
           onChange={onChange('byline')}
+        />
+      )}
+      {options.includes('maxWidth') && (
+        <Field
+          label='Maximale Breite'
+          value={node.data.get('maxWidth') || ''}
+          onChange={(_, px) => {
+            onChange('maxWidth', null, +px || undefined)
+          }}
         />
       )}
       {options.includes('count') && (


### PR DESCRIPTION
Depends on https://github.com/orbiting/styleguide/pull/316

<img width="1168" alt="Screenshot 2020-08-18 at 17 42 30" src="https://user-images.githubusercontent.com/410211/90536236-10118780-e17c-11ea-9436-4842f254a9a8.png">
