### PR TITLE
fix(editor): Debounce query request and render loading spinner

### DIFF
--- a/components/editor/modules/link/ui.js
+++ b/components/editor/modules/link/ui.js
@@ -1,7 +1,12 @@
 import { Text } from 'slate'
 import React, { Component } from 'react'
 import { graphql } from 'react-apollo'
-import { Label, Field, Autocomplete } from '@project-r/styleguide'
+import {
+  Label,
+  Field,
+  Autocomplete,
+  InlineSpinner
+} from '@project-r/styleguide'
 import LinkIcon from 'react-icons/lib/fa/chain'
 import UIForm from '../../UIForm'
 import createOnFieldChange from '../../utils/createOnFieldChange'
@@ -9,6 +14,7 @@ import RepoSearch from '../../utils/RepoSearch'
 import { AutoSlugLinkInfo } from '../../utils/github'
 import withT from '../../../../lib/withT'
 import gql from 'graphql-tag'
+import debounce from 'lodash.debounce'
 
 import { createInlineButton, matchInline, buttonStyles } from '../../utils'
 
@@ -52,14 +58,33 @@ const UserItem = ({ user }) => (
 
 const ConnectedAutoComplete = graphql(getUsers, {
   skip: props => !props.filter,
-  options: ({ filter }) => ({ variables: { search: filter } }),
-  props: ({ data: { users = [] } }) => ({
-    items: users.slice(0, 5).map(user => ({
-      value: user,
-      element: <UserItem user={user} />
-    }))
+  options: ({ search }) => ({ variables: { search } }),
+  props: ({ data }) => ({
+    data: data,
+    items:
+      data.loading ||
+      data.users.slice(0, 5).map(user => ({
+        value: user,
+        element: <UserItem user={user} />
+      }))
   })
-})(Autocomplete)
+})(props => (
+  <span style={{ position: 'relative', display: 'block' }}>
+    <Autocomplete key='autocomplete' {...props} />
+    {props.data?.loading && (
+      <span
+        style={{
+          position: 'absolute',
+          top: '21px',
+          right: '0px',
+          zIndex: 500
+        }}
+      >
+        <InlineSpinner size={35} />
+      </span>
+    )}
+  </span>
+))
 
 const SearchUserForm = withT(
   class extends Component {
@@ -68,17 +93,32 @@ const SearchUserForm = withT(
       this.state = {
         items: [],
         filter: '',
+        search: '',
         value: null
       }
       this.filterChangeHandler = this.filterChangeHandler.bind(this)
       this.changeHandler = this.changeHandler.bind(this)
+      this.setSearchValue = debounce(this.setSearchValue.bind(this), 500)
+    }
+
+    componentWillUnmount() {
+      this.setSearchValue.cancel()
+    }
+
+    setSearchValue() {
+      this.setState({
+        search: this.state.filter
+      })
     }
 
     filterChangeHandler(value) {
-      this.setState(state => ({
-        ...this.state,
-        filter: value
-      }))
+      this.setState(
+        state => ({
+          ...this.state,
+          filter: value
+        }),
+        this.setSearchValue
+      )
     }
 
     changeHandler(value) {
@@ -92,7 +132,7 @@ const SearchUserForm = withT(
     }
 
     render() {
-      const { filter, value } = this.state
+      const { filter, value, search } = this.state
       return (
         <ConnectedAutoComplete
           label={this.props.t(
@@ -103,6 +143,7 @@ const SearchUserForm = withT(
           filter={filter}
           value={value}
           items={[]}
+          search={search}
           onChange={this.changeHandler}
           onFilterChange={this.filterChangeHandler}
         />


### PR DESCRIPTION
Component sent with each keystroke a query request. Since users query is database intensive, each keystroke landed in query backlog and reduced response speed greatly.

Debounce and loading spinner approach is a blunt copy of [editor/utils/RepoSearch](https://github.com/orbiting/publikator-frontend/blob/master/components/editor/utils/RepoSearch.js).

![final_5fa264e142499e00afebcc7d_144741](https://user-images.githubusercontent.com/331800/98087041-d9e0cb80-1e7f-11eb-8bc2-1ec678ccbc5e.gif)