### PR TITLE
Dark Charts

### DIFF
--- a/components/editor/modules/dynamiccomponent/EditOverlay.js
+++ b/components/editor/modules/dynamiccomponent/EditOverlay.js
@@ -193,7 +193,7 @@ const EditOverlay = props => {
     })
   }
   return (
-    <OverlayFormManager showEditButton={false} {...props} onChange={onChange}>
+    <OverlayFormManager {...props} onChange={onChange}>
       {({ data, onChange }) => (
         <Form
           data={data}

--- a/components/editor/modules/dynamiccomponent/index.js
+++ b/components/editor/modules/dynamiccomponent/index.js
@@ -65,8 +65,8 @@ const DynamicComponent = ({ rule, subModules, TYPE }) => {
       type: TYPE,
       isVoid: true,
       data: {
-        src: (SG_DYNAMIC_COMPONENT_BASE_URLS || '').split(',')[0],
-        autoHtml: true
+        identifier: 'TK',
+        autoHtml: false
       }
     })
 

--- a/components/editor/utils/OverlayForm.js
+++ b/components/editor/utils/OverlayForm.js
@@ -8,7 +8,9 @@ import {
   OverlayToolbar,
   OverlayToolbarClose,
   OverlayBody,
-  mediaQueries
+  mediaQueries,
+  ColorContextProvider,
+  useColorContext
 } from '@project-r/styleguide'
 
 const previewWidth = 290
@@ -25,9 +27,6 @@ const styles = {
     }
   }),
   preview: css({
-    overflow: 'auto',
-    position: 'relative',
-    zIndex: 0,
     [mediaQueries.mUp]: {
       float: 'left',
       width: previewWidth
@@ -39,37 +38,60 @@ const styles = {
       width: `calc(100% - ${previewWidth}px)`,
       paddingLeft: 20
     }
+  }),
+  contextBackground: css({
+    position: 'relative',
+    zIndex: 0,
+    overflow: 'auto',
+    padding: '10px 15px',
+    margin: '0 -15px'
   })
 }
 
-class OverlayForm extends Component {
-  constructor(...args) {
-    super(...args)
-  }
-  render() {
-    const { onClose, preview, extra, children } = this.props
+const ContextBackground = ({ children }) => {
+  const [colorScheme] = useColorContext()
 
-    return (
-      <Overlay
-        onClose={onClose}
-        mUpStyle={{ maxWidth: '80vw', marginTop: '5vh' }}
-      >
-        <OverlayToolbar>
-          <OverlayToolbarClose onClick={onClose} />
-        </OverlayToolbar>
+  return (
+    <div
+      {...colorScheme.set('color', 'text')}
+      {...colorScheme.set('backgroundColor', 'default')}
+      {...styles.contextBackground}
+    >
+      {children}
+    </div>
+  )
+}
 
-        <OverlayBody>
-          <div {...styles.preview}>
-            {preview}
-            <br />
-            {extra}
-          </div>
-          <div {...styles.edit}>{children}</div>
-          <br style={{ clear: 'both' }} />
-        </OverlayBody>
-      </Overlay>
-    )
-  }
+const OverlayForm = props => {
+  const [colorScheme] = useColorContext()
+  const { onClose, preview, extra, children } = props
+
+  return (
+    <Overlay
+      onClose={onClose}
+      mUpStyle={{ maxWidth: '80vw', marginTop: '5vh' }}
+    >
+      <OverlayToolbar>
+        <OverlayToolbarClose onClick={onClose} />
+      </OverlayToolbar>
+
+      <OverlayBody>
+        <div {...styles.preview}>
+          <ContextBackground>{preview}</ContextBackground>
+          <br />
+          <ColorContextProvider
+            colorSchemeKey={colorScheme.schemeKey === 'dark' ? 'light' : 'dark'}
+          >
+            <ContextBackground>{preview}</ContextBackground>
+          </ColorContextProvider>
+          <br />
+          {extra}
+        </div>
+        <div {...styles.edit}>{children}</div>
+        <br style={{ clear: 'both' }} />
+      </OverlayBody>
+    </Overlay>
+  )
 }
 
 OverlayForm.propTypes = {

--- a/components/editor/utils/OverlayFormManager.js
+++ b/components/editor/utils/OverlayFormManager.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import SlatePropTypes from 'slate-prop-types'
 import { css } from 'glamor'
+import { useColorContext } from '@project-r/styleguide'
 
 import MdEdit from 'react-icons/lib/md/edit'
 
@@ -20,11 +21,14 @@ const styles = {
   })
 }
 
-const EditButton = ({ onClick }) => (
-  <div {...styles.editButton} role='button' onClick={onClick}>
-    <MdEdit />
-  </div>
-)
+const EditButton = ({ onClick }) => {
+  const [colorScheme] = useColorContext()
+  return (
+    <div {...styles.editButton} role='button' onClick={onClick}>
+      <MdEdit {...colorScheme.set('fill', 'text')} />
+    </div>
+  )
+}
 
 class OverlayFormManager extends Component {
   constructor(...args) {

--- a/components/editor/utils/OverlayFormManager.js
+++ b/components/editor/utils/OverlayFormManager.js
@@ -11,8 +11,6 @@ import OverlayForm from './OverlayForm'
 const styles = {
   editButton: css({
     position: 'absolute',
-    left: -40,
-    top: 0,
     zIndex: 1,
     fontSize: 24,
     ':hover': {
@@ -21,10 +19,19 @@ const styles = {
   })
 }
 
-const EditButton = ({ onClick }) => {
+const EditButton = ({ onClick, size, parentType }) => {
   const [colorScheme] = useColorContext()
+
   return (
-    <div {...styles.editButton} role='button' onClick={onClick}>
+    <div
+      {...styles.editButton}
+      role='button'
+      onClick={onClick}
+      style={{
+        top: size === 'breakout' || !parentType ? -40 : 0,
+        left: !parentType ? 0 : -40
+      }}
+    >
       <MdEdit {...colorScheme.set('fill', 'text')} />
     </div>
   )
@@ -43,7 +50,6 @@ class OverlayFormManager extends Component {
       node,
       attributes,
       onChange,
-      showEditButton,
       component,
       preview,
       extra,
@@ -53,6 +59,7 @@ class OverlayFormManager extends Component {
       this.setState({ showModal: true })
     }
     const showModal = this.state.showModal || node.data.get('isNew')
+    const parent = editor.value.document.getParent(node.key)
 
     return (
       <div
@@ -60,7 +67,11 @@ class OverlayFormManager extends Component {
         style={{ position: 'relative' }}
         onDoubleClick={startEditing}
       >
-        {showEditButton && <EditButton onClick={startEditing} />}
+        <EditButton
+          size={node.data.get('size')}
+          parentType={parent.type}
+          onClick={startEditing}
+        />
         {showModal && (
           <OverlayForm
             preview={preview}
@@ -84,12 +95,7 @@ class OverlayFormManager extends Component {
   }
 }
 
-OverlayFormManager.defaultProps = {
-  showEditButton: true
-}
-
 OverlayFormManager.propTypes = {
-  showEditButton: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   children: PropTypes.func.isRequired,
   component: PropTypes.node,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2318,9 +2318,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-10.3.1.tgz",
-      "integrity": "sha512-Fa7pXD/XODsAlzRirBSlYDqvXNmS6rYCVkHhzdjabvwudB7hVjW89sjjtEDbTNXli6/yxw3Q9Ku+QrOrlAnyVg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-10.5.0.tgz",
+      "integrity": "sha512-ndeKasZ0ym7kFwb/otsA8Ma2F4e647CfurSilvyeIfzGSNb1Cz/WA2YxqyQWarigHe+4QpdLhp9OgMBmvSsrfQ==",
       "requires": {
         "body-scroll-lock": "3.0.3",
         "react-icons": "^2.2.7"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.4",
-    "@project-r/styleguide": "10.3.1",
+    "@project-r/styleguide": "10.5.0",
     "@project-r/template-newsletter": "^1.5.0",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",


### PR DESCRIPTION
- Preview Charts in Opposite Color Scheme
- Show Edit Button for Dynamic Components
- Better Initial Dynamic Component State

<img width="777" alt="Screenshot 2020-11-20 at 22 51 25" src="https://user-images.githubusercontent.com/410211/99853352-1b14f300-2b83-11eb-95e8-0e07c1f7e73b.png">


<img width="770" alt="Screenshot 2020-11-20 at 22 50 54" src="https://user-images.githubusercontent.com/410211/99853405-2cf69600-2b83-11eb-99aa-236a6aa4e69b.png">
