### PR TITLE
Fix jumpy cursor in json (chart) editor

### DIFF
--- a/components/editor/utils/CodeEditorFields.js
+++ b/components/editor/utils/CodeEditorFields.js
@@ -83,7 +83,7 @@ export const JSONEditor = ({ label, value, onChange }) => {
   const previousValue = usePrevious(value)
 
   useEffect(() => {
-    if (JSON.stringify(previousValue) !== JSON.stringify(value)) {
+    if (!previousValue || value.type !== previousValue.type) {
       const stringified = JSON.stringify(value, null, 2)
       setStateValue(stringified)
     }


### PR DESCRIPTION
The generic solution is causing unwanted cursor jumps which I'm not keen on resolving just now. This should narrow the refresh scope to just chart type – which was the initial problem.