### PR TITLE
Ignore subject in meta

### DIFF
--- a/components/editor/modules/document/plain.js
+++ b/components/editor/modules/document/plain.js
@@ -53,12 +53,10 @@ export default ({ rule, subModules, TYPE }) => {
     if (title) {
       const headline = title.nodes.first()
       const headlineText = headline ? headline.text : ''
-      const subject = title.nodes.get(1)
       const lead = title.nodes.get(2)
 
       newData = newData
         .set('title', headlineText)
-        .set('subject', subject ? subject.text : '')
         .set('description', lead ? lead.text : '')
         .set('slug', slugify(headlineText))
     } else if (fallbackTitle) {

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -30,7 +30,6 @@ export const filterRepos = gql`
               shortTitle
               image
               description
-              subject
               credits
               kind
               color


### PR DESCRIPTION
Decided to no longer upsert `subject` prop in meta and query for it in RepoSearch.

Subject is an element before a documents lead. Its content was copied to `subject` prop in meta block.

If auto-flag – to keep meta title et al. in sync with document element – is falsy, UI does not offer input field or similar in meta block to update `subject` prop. This caused confusion on why subject in document is up-to-date but `subject` prop isn't.