### PR TITLE
Exclude templates in RepoSearch

### DIFF
--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -13,6 +13,7 @@ export const filterRepos = gql`
       after: $after
       search: $search
       template: $template
+      isTemplate: false
     ) {
       totalCount
       pageInfo {


### PR DESCRIPTION
This should exclude templates from repo searches.

There is never a need to link a template.

<img width="351" alt="Bildschirmfoto 2021-03-10 um 17 47 15" src="https://user-images.githubusercontent.com/331800/110665468-b11f6880-81c8-11eb-919d-f5bfdeaa4869.png">

