### PR TITLE
fix commit not working in preview mode

### DIFF
--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -213,7 +213,6 @@ class Editor extends Component {
   }
   render() {
     const { value, readOnly, hide } = this.props
-    console.log(hide)
     return (
       <Container hide={hide}>
         <Loader

--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -143,7 +143,11 @@ const styles = {
   })
 }
 
-const Container = ({ children }) => <div {...styles.container}>{children}</div>
+const Container = ({ children, hide }) => (
+  <div {...styles.container} style={{ display: hide ? 'none' : 'block' }}>
+    {children}
+  </div>
+)
 
 const Document = ({ children, readOnly }) => (
   <article
@@ -208,9 +212,10 @@ class Editor extends Component {
     }
   }
   render() {
-    const { value, readOnly } = this.props
+    const { value, readOnly, hide } = this.props
+    console.log(hide)
     return (
-      <Container>
+      <Container hide={hide}>
         <Loader
           loading={!value}
           render={() => (

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -935,18 +935,18 @@ export class EditorPage extends Component {
                         darkmode={this.state.previewDarkmode}
                       />
                     </ColorContextProvider>
-                  ) : (
-                    <Editor
-                      ref={this.editorRef}
-                      schema={schema}
-                      isTemplate={isTemplate}
-                      meta={meta}
-                      value={editorState}
-                      onChange={this.changeHandler}
-                      onDocumentChange={this.documentChangeHandler}
-                      readOnly={readOnly}
-                    />
-                  )}
+                  ) : null}
+                  <Editor
+                    ref={this.editorRef}
+                    schema={schema}
+                    isTemplate={isTemplate}
+                    meta={meta}
+                    value={editorState}
+                    onChange={this.changeHandler}
+                    onDocumentChange={this.documentChangeHandler}
+                    readOnly={readOnly}
+                    hide={this.state.previewScreenSize !== null}
+                  />
                 </ColorContextProvider>
               </div>
             )}


### PR DESCRIPTION
Problem: Previously the editor component was unmounted when the screen size preview was shown. This prevented users from committing changes from the preview view (infinite loading screen / `this.editor.serializer.deserialize(json)` was undefined). To fix that, the new version doesn't unmount the editor component but just puts `display: hide `on its container so that the preview iframe can render properly and users can commit changes from it.  