### PR TITLE
set 'image' as share image placeholder

### DIFF
--- a/components/editor/modules/meta/ShareImageForm.js
+++ b/components/editor/modules/meta/ShareImageForm.js
@@ -50,6 +50,7 @@ const UploadImage = withT(({ t, data, onInputChange, socialKey }) => {
         imageStyles={socialPreviewStyles[socialKey]}
         label={t(`metaData/field/${imageKey}`)}
         src={data.get(imageKey)}
+        placeholder={data.get('image')}
         onChange={onInputChange(imageKey)}
       />
     </div>
@@ -99,9 +100,13 @@ const PreviewText = ({ data, socialKey }) => {
 }
 
 const ShareImageForm = withT(({ t, editor, node, onInputChange, format }) => {
-  const generated = !!(node.data.get('shareText') || node.data.get('shareFontSize') || node.data.get('shareTextPosition'))
+  const generated = !!(
+    node.data.get('shareText') ||
+    node.data.get('shareFontSize') ||
+    node.data.get('shareTextPosition')
+  )
 
-  const setGenerated = (generated) => {
+  const setGenerated = generated => {
     if (generated) {
       editor.change(change => {
         change.setNodeByKey(node.key, {

--- a/components/editor/utils/ImageInput.js
+++ b/components/editor/utils/ImageInput.js
@@ -69,6 +69,7 @@ const ImageInput = ({
   label,
   maxHeight,
   imageStyles,
+  placeholder,
   maxWidth = 200
 }) => (
   <div style={{ position: 'relative' }}>
@@ -84,7 +85,7 @@ const ImageInput = ({
         />
       )}
       <img
-        src={src || '/static/placeholder.png'}
+        src={src || placeholder || '/static/placeholder.png'}
         {...imageStyles}
         style={{
           maxWidth,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,9 +2374,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-11.1.0.tgz",
-      "integrity": "sha512-/3TmyqHTHF0hDraLx9VsxAiGt1LA01T5zC2o31Cw9IKKRVsSSId6LtVTOYdayYxRO/UB4gd2fldsycY4Mm48OQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-11.1.1.tgz",
+      "integrity": "sha512-njZZOj5o7JL8gDH5zd7Xk8xnOk5XXsgRr7CiqgWwpiGXIYPV6S+/uoRXWYR4lij1Dd12Hu+KADf6L00p+yM3Gg==",
       "requires": {
         "body-scroll-lock": "3.0.3",
         "react-icons": "^2.2.7"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.4",
-    "@project-r/styleguide": "11.1.0",
+    "@project-r/styleguide": "11.1.1",
     "@project-r/template-newsletter": "^1.5.0",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",


### PR DESCRIPTION
Address wish of production to visualise default 'image' as share image when no medium-specific share image is set.