### PR TITLE
Extend series labeling

### DIFF
--- a/components/Calendar/graphql.js
+++ b/components/Calendar/graphql.js
@@ -20,6 +20,17 @@ const repoFragment = `
           title
           series {
             title
+            overview {
+              id
+              repoId
+            }
+            episodes {
+              label
+              document {
+                id
+                repoId
+              }
+            }
           }
           section {
             id

--- a/components/Repo/Table.js
+++ b/components/Repo/Table.js
@@ -57,6 +57,17 @@ export const filterAndOrderRepos = gql`
               credits
               series {
                 title
+                overview {
+                  id
+                  repoId
+                }
+                episodes {
+                  label
+                  document {
+                    id
+                    repoId
+                  }
+                }
               }
               section {
                 id

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -331,6 +331,14 @@
       "value": "Template wurde archiviert und kann nicht bearbeitet oder verwendet werden."
     },
     {
+      "key": "repo/label/series/episode",
+      "value": "Episode {number}"
+    },
+    {
+      "key": "repo/label/series/overview",
+      "value": "Serie"
+    },
+    {
       "key": "baseCommit/title",
       "value": "Ausgangsversion:"
     },

--- a/lib/utils/repo.js
+++ b/lib/utils/repo.js
@@ -3,12 +3,36 @@ import { t } from '../withT'
 
 export const getLabel = repo => {
   const {
+    id: repoId,
     latestCommit: {
       document: { meta }
     }
   } = repo
+
+  if (meta.series) {
+    const { title, overview, episodes } = meta.series
+
+    const isTitleDifferent = meta.title !== title
+    const isOverview = overview?.repoId === repoId
+
+    const index = episodes?.findIndex(e => e.document?.repoId === repoId)
+    const label = index >= 0 && episodes[index].label
+    const number =
+      index >= 0 &&
+      !label &&
+      t('repo/label/series/episode', { number: index + 1 })
+
+    return [
+      isTitleDifferent && title,
+      isOverview && t('repo/label/series/overview'),
+      label,
+      number
+    ]
+      .filter(Boolean)
+      .join(' – ')
+  }
+
   return (
-    meta.series?.title ||
     meta.section?.meta.title ||
     meta.format?.meta.title ||
     meta.dossier?.meta.title ||


### PR DESCRIPTION
In repo (and calendar) view, series will show with an episode label if available. A series overview document is labeled as such, too.

<img width="514" alt="Bildschirmfoto 2021-06-11 um 20 48 17" src="https://user-images.githubusercontent.com/331800/121735567-97a6f900-caf6-11eb-8009-3c90013de63e.png">

This will sharply increase productivity.
