### PR TITLE
Update Social Preview and add SEO Preview

### DIFF
--- a/components/editor/modules/meta/GooglePreview.js
+++ b/components/editor/modules/meta/GooglePreview.js
@@ -22,7 +22,13 @@ function wordTrim(text, length) {
   return text
 }
 
-const GooglePreview = ({ title, description, path, publishDate, t }) => {
+const GooglePreview = ({
+  title = '',
+  description = '',
+  path = '',
+  publishDate,
+  t
+}) => {
   let pathSegments = path.split('/').filter(Boolean)
 
   const hasDateSegement = path.match(/^\/[0-9]{4}\/[0-9]{2}\/[0-9]{2}\//)

--- a/components/editor/modules/meta/GooglePreview.js
+++ b/components/editor/modules/meta/GooglePreview.js
@@ -1,0 +1,101 @@
+import React from 'react'
+import { Label } from '@project-r/styleguide'
+import { timeFormat } from 'd3-time-format'
+
+import { FRONTEND_BASE_URL } from '../../../../lib/settings'
+import withT from '../../../../lib/withT'
+
+const urlSeparator = ' › '
+
+const formatDate = timeFormat('%d.%m.%Y')
+
+function wordTrim(text, length) {
+  if (text.length > length) {
+    return (
+      text
+        .slice(0, length)
+        .split(' ')
+        .slice(0, -1)
+        .join(' ') + ' ...'
+    )
+  }
+  return text
+}
+
+const GooglePreview = ({ title, description, path, publishDate, t }) => {
+  let pathSegments = path.split('/').filter(Boolean)
+
+  const hasDateSegement = path.match(/^\/[0-9]{4}\/[0-9]{2}\/[0-9]{2}\//)
+  if (hasDateSegement) {
+    pathSegments = [
+      pathSegments.slice(0, 3).join('/'),
+      ...pathSegments.slice(3)
+    ]
+  }
+  let remainingPathChars = 25
+  pathSegments = pathSegments
+    .map(segment => {
+      if (remainingPathChars <= 0) {
+        return
+      }
+      let visible = segment
+      if (segment.length > remainingPathChars) {
+        visible = segment.slice(0, remainingPathChars) + '...'
+        remainingPathChars = 0
+      } else {
+        remainingPathChars -= segment.length
+      }
+      return visible
+    })
+    .filter(Boolean)
+
+  return (
+    <>
+      <Label>{t('metaData/field/googlePreview')}</Label>
+      <div
+        style={{
+          maxWidth: 600 + 20,
+          fontFamily: 'arial, sans-serif',
+          fontSize: 14,
+          lineHeight: 1.58,
+          color: '#5f6368',
+          backgroundColor: '#fff',
+          padding: 10
+        }}
+      >
+        <a style={{ margin: 0, lineHeight: 1.3 }}>
+          <span style={{ color: '#202124' }}>{FRONTEND_BASE_URL}</span>
+          {urlSeparator}
+          {pathSegments.join(urlSeparator)}
+        </a>
+        <h3
+          style={{
+            margin: 0,
+            marginBottom: 3,
+            paddingTop: 4,
+            fontSize: 20,
+            fontWeight: 'normal',
+            lineHeight: 1.3,
+            color: 'rgb(26, 13, 171)'
+          }}
+        >
+          {wordTrim(title, 65)}
+        </h3>
+        <p style={{ margin: 0, color: '#4d5156' }}>
+          {publishDate && (
+            <span style={{ color: '#70757a' }}>
+              {formatDate(publishDate)}
+              {' — '}
+            </span>
+          )}
+          {wordTrim(description, publishDate ? 140 : 160)}
+        </p>
+      </div>
+      <div style={{ marginTop: 5 }}>
+        <Label>{t('metaData/field/googlePreview/note')}</Label>
+      </div>
+    </>
+  )
+}
+
+export default withT(GooglePreview)

--- a/components/editor/modules/meta/ShareImageForm.js
+++ b/components/editor/modules/meta/ShareImageForm.js
@@ -7,14 +7,19 @@ import {
   SharePreviewFacebook,
   SharePreviewTwitter,
   socialPreviewStyles,
+  socialPreviewWidth,
   Label,
   SHARE_IMAGE_DEFAULTS,
+  SHARE_IMAGE_HEIGHT,
+  SHARE_IMAGE_WIDTH,
   Radio
 } from '@project-r/styleguide'
 import ImageInput from '../../utils/ImageInput'
 import withT from '../../../../lib/withT'
 
 export const SOCIAL_MEDIA = ['facebook', 'twitter']
+
+const imageHeightRatio = SHARE_IMAGE_HEIGHT / SHARE_IMAGE_WIDTH
 
 const previews = {
   facebook: SharePreviewFacebook,
@@ -42,11 +47,15 @@ const UploadImage = withT(({ t, data, onInputChange, socialKey }) => {
   const imageKey = socialKey + 'Image'
   const labelHeight = 17 + 5
 
+  const width = socialPreviewWidth[socialKey] || 600
+  const height = width * imageHeightRatio
+
   return (
-    <div style={{ height: 314 + labelHeight, width: 600, overflow: 'hidden' }}>
+    <div style={{ height: height + labelHeight, width, overflow: 'hidden' }}>
       <ImageInput
-        maxWidth='100%'
-        maxHeight={314}
+        width={width}
+        height={height}
+        maxWidth='none'
         imageStyles={socialPreviewStyles[socialKey]}
         label={t(`metaData/field/${imageKey}`)}
         src={data.get(imageKey)}

--- a/components/editor/modules/meta/ShareImageForm.js
+++ b/components/editor/modules/meta/ShareImageForm.js
@@ -202,6 +202,9 @@ const ShareImageForm = withT(({ t, editor, node, onInputChange, format }) => {
             />
           )}
           <PreviewText data={data} socialKey={socialKey} />
+          <div style={{ marginTop: 5 }}>
+            <Label>{t(`metaData/field/${socialKey}Preview/note`)}</Label>
+          </div>
           <br />
         </Fragment>
       ))}
@@ -209,4 +212,4 @@ const ShareImageForm = withT(({ t, editor, node, onInputChange, format }) => {
   )
 })
 
-export default ShareImageForm
+export default withT(ShareImageForm)

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -77,7 +77,13 @@ const MetaData = ({
   )
 
   const onInputChange = key => (_, inputValue) => {
-    const newData = key !== 'auto' ? node.data.remove('auto') : node.data
+    let newData = node.data
+    if (key === 'title' || key === 'description') {
+      newData = newData.remove('auto')
+    }
+    if (key === 'slug') {
+      newData = newData.remove('autoSlug')
+    }
     editor.change(change => {
       change.setNodeByKey(node.key, {
         data:
@@ -259,6 +265,17 @@ const MetaData = ({
           value={node.data.get('slug')}
           onChange={onInputChange('slug')}
           isTemplate={isTemplate}
+          icon={
+            <span style={{ display: 'inline-block', paddingTop: 10 }}>
+              <Checkbox
+                checked={node.data.get('autoSlug')}
+                onChange={onInputChange('autoSlug')}
+                black
+              >
+                <span style={{ verticalAlign: 'top' }}>automatisch</span>
+              </Checkbox>
+            </span>
+          }
         />
         <br />
         {!isTemplate && mdastSchema && mdastSchema.getPath && (

--- a/components/editor/modules/meta/ui.js
+++ b/components/editor/modules/meta/ui.js
@@ -18,6 +18,7 @@ import AudioForm from './AudioForm'
 import UIForm from '../../UIForm'
 import DarkModeForm, { DARK_MODE_KEY } from './DarkModeForm'
 import ShareImageForm from './ShareImageForm'
+import GooglePreview from './GooglePreview'
 
 const styles = {
   container: css({
@@ -67,6 +68,12 @@ const MetaData = ({
   )
   const genericData = genericDefaultValues.merge(
     node.data.filter((_, key) => genericKeys.has(key))
+  )
+
+  const seoKeys = Set(['seoTitle', 'seoDescription'])
+  const seoDefaultValues = Map(seoKeys.map(key => [key, '']))
+  const seoData = seoDefaultValues.merge(
+    node.data.filter((_, key) => seoKeys.has(key))
   )
 
   const onInputChange = key => (_, inputValue) => {
@@ -130,6 +137,15 @@ const MetaData = ({
 
   const customFieldsRest = customFields.filter(f => !f.ref)
 
+  const previewPublishDate = contextMeta.publishDate
+    ? new Date(contextMeta.publishDate)
+    : new Date()
+  const previewPath = mdastSchema.getPath({
+    ...dataAsJs,
+    publishDate: previewPublishDate,
+    slug: slugify(dataAsJs.slug || '')
+  })
+
   return (
     <div {...styles.container}>
       <div {...styles.center}>
@@ -143,45 +159,6 @@ const MetaData = ({
             {t('metaData/field/auto')}
           </Checkbox>
         </div>
-        <br />
-        <SlugField
-          black
-          label={t(
-            `metaData/field/${isTemplate ? 'repoSlug' : 'slug'}`,
-            undefined,
-            'slug'
-          )}
-          value={node.data.get('slug')}
-          onChange={onInputChange('slug')}
-          isTemplate={isTemplate}
-        />
-        {!isTemplate && mdastSchema && mdastSchema.getPath && (
-          <Label>
-            {t('metaData/field/slug/note', {
-              base: FRONTEND_BASE_URL
-                ? FRONTEND_BASE_URL.replace(/https?:\/\/(www\.)?/, '')
-                : '',
-              path: mdastSchema.getPath({
-                ...dataAsJs,
-                publishDate: contextMeta.publishDate
-                  ? new Date(contextMeta.publishDate)
-                  : new Date(),
-                slug: slugify(dataAsJs.slug || '')
-              })
-            })}
-            <br />
-            {!!dataAsJs.path && (
-              <>
-                {t('metaData/field/slug/pathNote', {
-                  base: FRONTEND_BASE_URL.replace(/https?:\/\/(www\.)?/, ''),
-                  path: dataAsJs.path
-                })}
-                <br />
-              </>
-            )}
-            <br />
-          </Label>
-        )}
         <MetaForm
           data={genericData}
           onInputChange={onInputChange}
@@ -269,6 +246,55 @@ const MetaData = ({
           format={titleData?.format?.meta}
           editor={editor}
           node={node}
+        />
+        <br />
+        <MetaForm data={seoData} onInputChange={onInputChange} black />
+        <SlugField
+          black
+          label={t(
+            `metaData/field/${isTemplate ? 'repoSlug' : 'slug'}`,
+            undefined,
+            'slug'
+          )}
+          value={node.data.get('slug')}
+          onChange={onInputChange('slug')}
+          isTemplate={isTemplate}
+        />
+        <br />
+        {!isTemplate && mdastSchema && mdastSchema.getPath && (
+          <Label>
+            {t('metaData/field/slug/note', {
+              base: FRONTEND_BASE_URL
+                ? FRONTEND_BASE_URL.replace(/https?:\/\/(www\.)?/, '')
+                : '',
+              path: previewPath
+            })}
+            <br />
+            {!!dataAsJs.path && (
+              <>
+                {t('metaData/field/slug/pathNote', {
+                  base: FRONTEND_BASE_URL.replace(/https?:\/\/(www\.)?/, ''),
+                  path: dataAsJs.path
+                })}
+                <br />
+              </>
+            )}
+            <br />
+          </Label>
+        )}
+        <GooglePreview
+          title={
+            node.data.get('seoTitle') ||
+            node.data.get('twitterTitle') ||
+            node.data.get('title')
+          }
+          description={
+            node.data.get('seoDescription') ||
+            node.data.get('twitterDescription') ||
+            node.data.get('description')
+          }
+          publishDate={previewPublishDate}
+          path={dataAsJs.path || previewPath}
         />
         <br />
         <br />

--- a/components/editor/utils/ImageInput.js
+++ b/components/editor/utils/ImageInput.js
@@ -70,7 +70,9 @@ const ImageInput = ({
   maxHeight,
   imageStyles,
   placeholder,
-  maxWidth = 200
+  maxWidth = 200,
+  width,
+  height
 }) => (
   <div style={{ position: 'relative' }}>
     <label>
@@ -91,7 +93,9 @@ const ImageInput = ({
           maxWidth,
           maxHeight,
           objectFit: 'cover',
-          width: src ? undefined : '100%',
+          objectPosition: 'center',
+          width: width || (src ? undefined : '100%'),
+          height,
           backgroundColor: dark ? '#1F1F1F' : '#fff'
         }}
         alt=''

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -530,7 +530,7 @@
     },
     {
       "key": "metaData/field/facebookPreview/note",
-      "value": "Sichtbare Textlänge varriert nach Bildschirmgrösse. Sobald der Titel zweizeilig wird, wird der Lead meist ausgeblendet. Auf Mobile passiert dies bereits ab 40 bis 50 Zeichen."
+      "value": "Sobald der Titel zweizeilig wird, wird der Lead meist ausgeblendet. Auf Mobile passiert dies bereits ab 40 bis 50 Zeichen. Sichtbare Textlänge varriert nach Bildschirmgrösse. "
     },
     {
       "key": "metaData/field/twitterTitle",
@@ -550,7 +550,7 @@
     },
     {
       "key": "metaData/field/twitterPreview/note",
-      "value": "Sichtbare Textlänge varriert nach Bildschirmgrösse und Ansicht. Auf Mobile wird der Lead meist nicht angezeigt."
+      "value": "Auf Mobile wird der Lead meist nicht angezeigt. Sichtbare Textlänge varriert nach Bildschirmgrösse und Ansicht."
     },
     {
       "key": "metaData/field/seoTitle",
@@ -566,7 +566,7 @@
     },
     {
       "key": "metaData/field/googlePreview/note",
-      "value": "Der Lead wird allenfalls durch ein Textausschnitt ersetzt sofern es der Suchanfrage mehr entspricht. Sofern nicht explizit definiert erscheinen Twitter oder allgemeine Titel und Leads."
+      "value": "Google verwendet einen Textausschnitt statt den Lead, falls es mehr zur Suchanfrage passt. Sofern nicht explizit definiert erscheinen Twitter oder allgemeine Titel und Leads."
     },
     {
       "key": "metaData/field/href",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -545,6 +545,22 @@
       "value": "Twitter Vorschau"
     },
     {
+      "key": "metaData/field/seoTitle",
+      "value": "SEO Titel"
+    },
+    {
+      "key": "metaData/field/seoDescription",
+      "value": "SEO Lead"
+    },
+    {
+      "key": "metaData/field/googlePreview",
+      "value": "Google Vorschau"
+    },
+    {
+      "key": "metaData/field/googlePreview/note",
+      "value": "Der Lead wird allenfalls durch ein Textausschnitt ersetzt sofern es der Suchanfrage mehr entspricht. Sofern nicht explizit definiert erscheinen Twitter oder allgemeine Titel und Leads."
+    },
+    {
       "key": "metaData/field/href",
       "value": "URL"
     },

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -529,6 +529,10 @@
       "value": "Facebook Vorschau"
     },
     {
+      "key": "metaData/field/facebookPreview/note",
+      "value": "Sichtbare Textlänge varriert nach Bildschirmgrösse. Sobald der Titel zweizeilig wird, wird der Lead meist ausgeblendet. Auf Mobile passiert dies bereits ab 40 bis 50 Zeichen."
+    },
+    {
       "key": "metaData/field/twitterTitle",
       "value": "Twitter Titel"
     },
@@ -543,6 +547,10 @@
     {
       "key": "metaData/field/twitterPreview",
       "value": "Twitter Vorschau"
+    },
+    {
+      "key": "metaData/field/twitterPreview/note",
+      "value": "Sichtbare Textlänge varriert nach Bildschirmgrösse und Ansicht. Auf Mobile wird der Lead meist nicht angezeigt."
     },
     {
       "key": "metaData/field/seoTitle",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -430,7 +430,7 @@
     },
     {
       "key": "metaData/field/auto",
-      "value": "Automatisch vom Titelblock ableiten (Titel, Lead & Slug)"
+      "value": "Automatisch vom Titelblock ableiten (Titel, Lead)"
     },
     {
       "key": "metaData/field/shortTitle",
@@ -554,11 +554,11 @@
     },
     {
       "key": "metaData/field/seoTitle",
-      "value": "SEO Titel"
+      "value": "SEO Titel (optional)"
     },
     {
       "key": "metaData/field/seoDescription",
-      "value": "SEO Lead"
+      "value": "SEO Lead (optional)"
     },
     {
       "key": "metaData/field/googlePreview",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,9 +2374,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-12.1.1.tgz",
-      "integrity": "sha512-eMQNJZ54wDHNYvRkfteuWZgMqsfjQooexxqBYwyLM6sknvLidwrT/+w6Zsa0M95Lp5ErnxW+Osa5g6SbUSqp0Q==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-12.2.0.tgz",
+      "integrity": "sha512-rULafSQZhHrSsV5dP7jdgqm4U+hnG44o2EEBFdJ3Kdyh92OrWeV+LKUykC7j1GMeMg+WqNMpg0bdlSbd5iP2nA==",
       "requires": {
         "@react-icons/all-files": "^4.1.0",
         "body-scroll-lock": "3.0.3"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@orbiting/remark-preset": "^1.2.4",
-    "@project-r/styleguide": "^12.1.1",
+    "@project-r/styleguide": "^12.2.0",
     "@project-r/template-newsletter": "^1.5.0",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",


### PR DESCRIPTION
Depends on https://github.com/orbiting/styleguide/pull/435

## Facebook

- style and width changes for the facebook preview
- lead now always cuts off after one line

<img width="634" alt="Screenshot FB Preview" src="https://user-images.githubusercontent.com/410211/135778872-8ed8be7b-8aa3-4d88-9127-6332af4d23d0.png">

## Twitter

- style update
- major width reduction

<img width="630" alt="Screenshot Twitter Preview" src="https://user-images.githubusercontent.com/410211/135778895-2de601de-4dbf-4c30-b174-d2879729975b.png">

## SEO

New SEO preview underneath social media preview

<img width="684" alt="Screenshot New SEO Preview" src="https://user-images.githubusercontent.com/410211/135778908-49e98df9-4958-484e-a55e-60b88dd68838.png">

- depends on Twitter title and lead
- moves slug adjacent to SEO preview
- keep slug auto filling now also based on Twitter title until edited