### PR TITLE
Improve copy paste

### DIFF
--- a/components/editor/modules/document/createPasteHtml.js
+++ b/components/editor/modules/document/createPasteHtml.js
@@ -14,6 +14,9 @@ const hasParent = (type, document, key) => {
   return parent.type === type ? true : hasParent(type, document, parent.key)
 }
 
+const removeBoldTags = html =>
+  html.replace(/<b[^>]*>/g, '').replace(/<\/b>/g, '')
+
 export default (centerModule, figureModule) => (event, change, editor) => {
   const transfer = getEventTransfer(event)
   if (transfer.type !== 'html') return
@@ -35,7 +38,7 @@ export default (centerModule, figureModule) => (event, change, editor) => {
     .use(rehype2remark)
     .use(stringify)
   const pastedMd = toMd.processSync(
-    isCenter || isCaption ? transfer.html : transfer.text
+    isCenter || isCaption ? removeBoldTags(transfer.html) : transfer.text
   )
   const currentSerializer = isCaption
     ? figureModule.helpers.captionSerializer


### PR DESCRIPTION
Chrome's gdoc version wraps a funny `<b>` tag around the whole copied content. If you remove it the parser is happy again.

_NB: Updating the parser might also help – but this caused import errors and might fit as part of a bigger dependencies update project for Publikator._