### PR TITLE
Filter series master, episode documents

### DIFF
--- a/components/editor/modules/meta/RepoSelect.js
+++ b/components/editor/modules/meta/RepoSelect.js
@@ -29,7 +29,14 @@ const styles = {
   })
 }
 
-export default ({ label, template, value, onChange }) => {
+export default ({
+  label,
+  template,
+  isSeriesMaster,
+  isSeriesEpisode,
+  value,
+  onChange
+}) => {
   const onRefChange = item => {
     onChange(
       undefined,
@@ -68,5 +75,13 @@ export default ({ label, template, value, onChange }) => {
     )
   }
 
-  return <RepoSearch label={label} template={template} onChange={onRefChange} />
+  return (
+    <RepoSearch
+      label={label}
+      template={template}
+      isSeriesMaster={isSeriesMaster}
+      isSeriesEpisode={isSeriesEpisode}
+      onChange={onRefChange}
+    />
+  )
 }

--- a/components/editor/modules/meta/SeriesForm.js
+++ b/components/editor/modules/meta/SeriesForm.js
@@ -193,6 +193,7 @@ export default withT(({ t, editor, node, onRepoInputChange, repoId }) => {
         <RepoSelect
           label={t('metaData/series/main')}
           value={value}
+          isSeriesMaster={true}
           onChange={onRepoInputChange('series')}
         />
       )}
@@ -235,6 +236,7 @@ export default withT(({ t, editor, node, onRepoInputChange, repoId }) => {
           <RepoSelect
             label={t('metaData/series/overview')}
             value={value.overview}
+            isSeriesMaster={true}
             onChange={(_, overview) => {
               onSeriesChange({
                 ...value,
@@ -365,6 +367,7 @@ export default withT(({ t, editor, node, onRepoInputChange, repoId }) => {
                 <RepoSelect
                   label={t('metaData/series/episodes/document')}
                   value={episodeDoc}
+                  isSeriesEpisode={true}
                   onChange={(_, url, item) => {
                     const newData = {
                       document: url

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -7,13 +7,21 @@ import debounce from 'lodash.debounce'
 import { GITHUB_ORG, REPO_PREFIX } from '../../../lib/settings'
 
 export const filterRepos = gql`
-  query searchRepo($after: String, $search: String, $template: String) {
+  query searchRepo(
+    $after: String
+    $search: String
+    $template: String
+    $isSeriesMaster: Boolean
+    $isSeriesEpisode: Boolean
+  ) {
     repos: reposSearch(
       first: 10
       after: $after
       search: $search
       template: $template
       isTemplate: false
+      isSeriesMaster: $isSeriesMaster
+      isSeriesEpisode: $isSeriesEpisode
     ) {
       totalCount
       pageInfo {
@@ -91,9 +99,9 @@ export const filterRepos = gql`
 
 const ConnectedAutoComplete = graphql(filterRepos, {
   skip: props => !props.filter,
-  options: ({ search, template }) => ({
+  options: ({ search, template, isSeriesEpisode, isSeriesMaster }) => ({
     fetchPolicy: 'network-only',
-    variables: { search: search, template: template }
+    variables: { search, template, isSeriesEpisode, isSeriesMaster }
   }),
   props: props => {
     if (props.data.loading) return { data: props.data, items: [] }
@@ -194,6 +202,8 @@ export default class RepoSearch extends Component {
         value={value}
         search={search}
         template={this.props.template}
+        isSeriesMaster={this.props.isSeriesMaster}
+        isSeriesEpisode={this.props.isSeriesEpisode}
         items={[]}
         onChange={this.changeHandler}
         onFilterChange={this.filterChangeHandler}


### PR DESCRIPTION
This Pull Request adds ability to repo select component to filter for series master and episode documents, as to avoid inplausable configurations. It depends on https://github.com/orbiting/backends/pull/673

On a series master document in meta block, it will search only for series master documents:
<img width="667" alt="Bildschirmfoto 2021-11-05 um 18 49 55" src="https://user-images.githubusercontent.com/331800/140556442-6211e296-ef26-490b-b44d-c1f95357cbbb.png">

And for episodes, it will search only for series episode documents:
<img width="644" alt="Bildschirmfoto 2021-11-05 um 18 50 05" src="https://user-images.githubusercontent.com/331800/140556458-2de89bb7-f5c9-417b-96f5-457170a0256e.png">

On a series episode document in meta block, it will search only for search master documents:
<img width="667" alt="Bildschirmfoto 2021-11-05 um 18 54 49" src="https://user-images.githubusercontent.com/331800/140556469-cbb4a561-84ad-49b4-ac88-289099777f9f.png">