### PR TITLE
Move elements up and down

### DIFF
--- a/components/editor/modules/blockquote/index.js
+++ b/components/editor/modules/blockquote/index.js
@@ -4,6 +4,8 @@ import { Block } from 'slate'
 
 import injectBlock from '../../utils/injectBlock'
 import { matchBlock, createBlockButton, buttonStyles } from '../../utils'
+import { matchAncestor } from '../../utils/matchers'
+import InlineUI from '../../utils/InlineUI'
 
 const getNewItem = options => {
   const [blocktextModule, captionModule] = options.subModules
@@ -106,11 +108,20 @@ const blockQuotePlugin = options => {
   const { blocktextModule, captionModule } = getSubmodules(options)
   const BlockQuote = options.rule.component
   return {
-    renderNode: ({ node, children, attributes }) => {
+    renderNode: ({ node, children, attributes, editor }) => {
       if (!matchBlock(options.TYPE)(node)) {
         return
       }
-      return <BlockQuote attributes={attributes}>{children}</BlockQuote>
+      return (
+        <div style={{ position: 'relative' }}>
+          <InlineUI
+            node={node}
+            editor={editor}
+            isMatch={matchAncestor(options.TYPE)}
+          />
+          <BlockQuote attributes={attributes}>{children}</BlockQuote>
+        </div>
+      )
     },
     schema: {
       blocks: {

--- a/components/editor/modules/chart/EditOverlay/index.js
+++ b/components/editor/modules/chart/EditOverlay/index.js
@@ -61,6 +61,7 @@ const Overlay = props => {
           })
         })
       }}
+      nested
     >
       {({ data, onChange }) => {
         const onChartSelect = (config, values, cleanup) => {

--- a/components/editor/modules/chart/EditOverlay/index.js
+++ b/components/editor/modules/chart/EditOverlay/index.js
@@ -61,7 +61,6 @@ const Overlay = props => {
           })
         })
       }}
-      nested
     >
       {({ data, onChange }) => {
         const onChartSelect = (config, values, cleanup) => {

--- a/components/editor/modules/chart/index.js
+++ b/components/editor/modules/chart/index.js
@@ -19,7 +19,6 @@ const CustomUi = ({ editor, node, TYPE, subModules }) => {
     <InlineUI
       node={node}
       editor={editor}
-      style={{ left: -100 }}
       isMatch={value => value.blocks.some(matchSubmodules(TYPE, subModules))}
     >
       <MarkButton onMouseDown={() => setShowModal(true)}>

--- a/components/editor/modules/chart/index.js
+++ b/components/editor/modules/chart/index.js
@@ -1,10 +1,33 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import MarkdownSerializer from 'slate-mdast-serializer'
 import { Block } from 'slate'
 
 import createUi from './ui'
 import { matchBlock } from '../../utils'
 import { createRemoveEmptyKeyHandler } from '../../utils/keyHandlers'
+import InlineUI, { MarkButton } from '../../utils/InlineUI'
+import MdEdit from 'react-icons/lib/md/edit'
+import { matchSubmodules } from '../../utils/matchers'
+import {
+  OverlayFormContext,
+  OverlayFormContextProvider
+} from '../../utils/OverlayFormContext'
+
+const CustomUi = ({ editor, node, TYPE, subModules }) => {
+  const { setShowModal } = useContext(OverlayFormContext)
+  return (
+    <InlineUI
+      node={node}
+      editor={editor}
+      style={{ left: -100 }}
+      isMatch={value => value.blocks.some(matchSubmodules(TYPE, subModules))}
+    >
+      <MarkButton onMouseDown={() => setShowModal(true)}>
+        <MdEdit size={20} />
+      </MarkButton>
+    </InlineUI>
+  )
+}
 
 export default ({ rule, subModules, TYPE }) => {
   const canvasModule = subModules.find(m => m.name === 'chartCanvas')
@@ -91,9 +114,17 @@ export default ({ rule, subModules, TYPE }) => {
         renderNode({ editor, node, children, attributes }) {
           if (!serializerRule.match(node)) return
           return (
-            <Container size={node.data.get('size')} attributes={attributes}>
-              {children}
-            </Container>
+            <OverlayFormContextProvider>
+              <Container size={node.data.get('size')} attributes={attributes}>
+                <CustomUi
+                  node={node}
+                  editor={editor}
+                  TYPE={TYPE}
+                  subModules={subModules}
+                />
+                {children}
+              </Container>
+            </OverlayFormContextProvider>
           )
         },
         onKeyDown: createRemoveEmptyKeyHandler({ TYPE, isEmpty }),

--- a/components/editor/modules/dynamiccomponent/index.js
+++ b/components/editor/modules/dynamiccomponent/index.js
@@ -1,4 +1,4 @@
-import React, { cloneElement } from 'react'
+import React, { cloneElement, useContext } from 'react'
 import { Block } from 'slate'
 
 import { matchBlock } from '../../utils'
@@ -8,10 +8,30 @@ import createUi from './ui'
 
 import EditOverlay from './EditOverlay'
 
-import { SG_DYNAMIC_COMPONENT_BASE_URLS } from '../../../../lib/settings'
-
 import dynamicComponentRequire from './require'
 import dynamicComponentIdentifiers from './identifiers'
+import InlineUI, { MarkButton } from '../../utils/InlineUI'
+import MdEdit from 'react-icons/lib/md/edit'
+import {
+  OverlayFormContext,
+  OverlayFormContextProvider
+} from '../../utils/OverlayFormContext'
+
+const CustomUi = ({ editor, node, TYPE }) => {
+  const { setShowModal } = useContext(OverlayFormContext)
+  return (
+    <InlineUI
+      node={node}
+      editor={editor}
+      style={{ left: -100 }}
+      isMatch={value => value.blocks.some(matchBlock(TYPE))}
+    >
+      <MarkButton onMouseDown={() => setShowModal(true)}>
+        <MdEdit size={20} />
+      </MarkButton>
+    </InlineUI>
+  )
+}
 
 const DynamicComponent = ({ rule, subModules, TYPE }) => {
   const { identifier = 'DYNAMIC_COMPONENT' } = rule.editorOptions || {}
@@ -85,7 +105,7 @@ const DynamicComponent = ({ rule, subModules, TYPE }) => {
     plugins: [
       {
         renderNode(props) {
-          const { node } = props
+          const { node, editor } = props
           if (node.type !== TYPE) return
           const data = node.data.toJS()
           const component = (
@@ -102,7 +122,16 @@ const DynamicComponent = ({ rule, subModules, TYPE }) => {
           })
 
           return (
-            <EditOverlay {...props} component={component} preview={preview} />
+            <OverlayFormContextProvider>
+              <div style={{ position: 'relative' }}>
+                <CustomUi node={node} editor={editor} TYPE={TYPE} />
+                <EditOverlay
+                  {...props}
+                  component={component}
+                  preview={preview}
+                />
+              </div>
+            </OverlayFormContextProvider>
           )
         },
         schema: {

--- a/components/editor/modules/dynamiccomponent/index.js
+++ b/components/editor/modules/dynamiccomponent/index.js
@@ -23,7 +23,6 @@ const CustomUi = ({ editor, node, TYPE }) => {
     <InlineUI
       node={node}
       editor={editor}
-      style={{ left: -100 }}
       isMatch={value => value.blocks.some(matchBlock(TYPE))}
     >
       <MarkButton onMouseDown={() => setShowModal(true)}>

--- a/components/editor/modules/embed/index.js
+++ b/components/editor/modules/embed/index.js
@@ -12,6 +12,8 @@ import EmbedLoader from './EmbedLoader'
 import gql from 'graphql-tag'
 import { FRONTEND_BASE_URL } from '../../../../lib/settings'
 import { stringify, parse } from '@orbiting/remark-preset'
+import { matchAncestor, matchSubmodules } from '../../utils/matchers'
+import InlineUI from '../../utils/InlineUI'
 
 const getVideoEmbed = gql`
   query getVideoEmbed($id: ID!, $embedType: EmbedType!) {
@@ -168,13 +170,22 @@ const embedPlugin = ({ query, ...options }) => {
 
   return {
     renderNode(props) {
-      const { node } = props
+      const { node, editor } = props
 
       if (!matchBlock(options.TYPE)(node)) {
         return
       }
 
-      return <Component {...props} />
+      return (
+        <div style={{ position: 'relative' }}>
+          <InlineUI
+            node={node}
+            editor={editor}
+            isMatch={value => value.blocks.some(matchBlock(options.TYPE))}
+          />
+          <Component {...props} />
+        </div>
+      )
     },
     schema: {
       blocks: {

--- a/components/editor/modules/figure/index.js
+++ b/components/editor/modules/figure/index.js
@@ -152,7 +152,6 @@ export default options => {
           return (
             <Figure {...node.data.toJS()} attributes={attributes}>
               <InlineUI
-                key='ui'
                 node={node}
                 editor={editor}
                 isMatch={value => {

--- a/components/editor/modules/figure/index.js
+++ b/components/editor/modules/figure/index.js
@@ -7,6 +7,8 @@ import { findOrCreate } from '../../utils/serialization'
 import { createRemoveEmptyKeyHandler } from '../../utils/keyHandlers'
 
 import MarkdownSerializer from 'slate-mdast-serializer'
+import InlineUI from '../../utils/InlineUI'
+import { isFigureGroup } from '../figuregroup/ui'
 
 const findP = (node, hasImage) =>
   node.children.find(
@@ -145,10 +147,22 @@ export default options => {
     }),
     plugins: [
       {
-        renderNode({ children, node, attributes }) {
+        renderNode({ children, node, attributes, editor }) {
           if (node.type !== TYPE) return
           return (
             <Figure {...node.data.toJS()} attributes={attributes}>
+              <InlineUI
+                key='ui'
+                node={node}
+                editor={editor}
+                isMatch={value => {
+                  const isFigureBlock = block =>
+                    block.type === FIGURE_IMAGE || block.type === FIGURE_CAPTION
+                  return (
+                    value.blocks.some(isFigureBlock) && !isFigureGroup(value)
+                  )
+                }}
+              />
               {children}
             </Figure>
           )

--- a/components/editor/modules/figuregroup/index.js
+++ b/components/editor/modules/figuregroup/index.js
@@ -113,12 +113,7 @@ const figureGroupPlugin = options => {
           slideshow={false}
           attributes={attributes}
         >
-          <InlineUI
-            key='ui'
-            node={node}
-            editor={editor}
-            isMatch={isFigureGroup}
-          />
+          <InlineUI node={node} editor={editor} isMatch={isFigureGroup} />
           {node.data.get('slideshow') > 0 && (
             <div style={{ position: 'absolute', left: -25 }}>
               <GalleryIcon />

--- a/components/editor/modules/figuregroup/index.js
+++ b/components/editor/modules/figuregroup/index.js
@@ -1,10 +1,11 @@
 import MarkdownSerializer from 'slate-mdast-serializer'
 import { Block } from 'slate'
 import React from 'react'
-import { FigureGroupButton, FigureGroupForm } from './ui'
+import { FigureGroupButton, FigureGroupForm, isFigureGroup } from './ui'
 import { matchBlock } from '../../utils'
 import { createRemoveEmptyKeyHandler } from '../../utils/keyHandlers'
 import GalleryIcon from 'react-icons/lib/md/filter'
+import InlineUI from '../../utils/InlineUI'
 
 export const getData = data => ({
   columns: 2,
@@ -40,9 +41,10 @@ export const fromMdast = ({ TYPE, subModules }) => (
 
   const caption = node.children[node.children.length - 1]
   const hasCaption = caption.type === 'paragraph'
-  const figures = (hasCaption ? node.children.slice(0, -1) : node.children).map(
-    v => figureSerializer.fromMdast(v)
-  )
+  const figures = (hasCaption
+    ? node.children.slice(0, -1)
+    : node.children
+  ).map(v => figureSerializer.fromMdast(v))
   const nodes = hasCaption
     ? figures.concat(captionModule.helpers.serializer.fromMdast(caption))
     : figures
@@ -94,7 +96,7 @@ const isEmpty = options => {
 }
 
 const figureGroupPlugin = options => {
-  const { TYPE, rule } = options
+  const { TYPE, rule, subModules } = options
   const [figureModule, captionModule] = options.subModules
 
   const FigureGroup = rule.component
@@ -111,6 +113,12 @@ const figureGroupPlugin = options => {
           slideshow={false}
           attributes={attributes}
         >
+          <InlineUI
+            key='ui'
+            node={node}
+            editor={editor}
+            isMatch={isFigureGroup}
+          />
           {node.data.get('slideshow') > 0 && (
             <div style={{ position: 'absolute', left: -25 }}>
               <GalleryIcon />

--- a/components/editor/modules/figuregroup/ui.js
+++ b/components/editor/modules/figuregroup/ui.js
@@ -86,18 +86,20 @@ const Form = ({ node, onChange }) => {
   )
 }
 
+export const isFigureGroup = value =>
+  value.blocks.reduce(
+    (memo, node) =>
+      memo || value.document.getFurthest(node.key, matchBlock('FIGUREGROUP')),
+    undefined
+  )
+
 export const FigureGroupForm = options => {
   const { TYPE } = options
   const addFigureHandler = addFigure(options)
   const unwrapFiguresHandler = unwrapFigures(options)
   return createPropertyForm({
     isDisabled: ({ value }) => {
-      const figureGroup = value.blocks.reduce(
-        (memo, node) =>
-          memo || value.document.getFurthest(node.key, matchBlock(TYPE)),
-        undefined
-      )
-
+      const figureGroup = isFigureGroup(value)
       return !figureGroup
     }
   })(({ disabled, onChange, value }) => {

--- a/components/editor/modules/figuregroup/ui.js
+++ b/components/editor/modules/figuregroup/ui.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Radio, Label } from '@project-r/styleguide'
 
-import { buttonStyles, createPropertyForm, matchBlock } from '../../utils'
+import { buttonStyles, createPropertyForm } from '../../utils'
 
 import injectBlock from '../../utils/injectBlock'
 
@@ -10,6 +10,7 @@ import UIForm from '../../UIForm'
 import createOnFieldChange from '../../utils/createOnFieldChange'
 
 import { getNewBlock } from './'
+import { matchAncestor } from '../../utils/matchers'
 
 const addFigure = options => {
   const [figureModule] = options.subModules
@@ -86,15 +87,9 @@ const Form = ({ node, onChange }) => {
   )
 }
 
-export const isFigureGroup = value =>
-  value.blocks.reduce(
-    (memo, node) =>
-      memo || value.document.getFurthest(node.key, matchBlock('FIGUREGROUP')),
-    undefined
-  )
+export const isFigureGroup = matchAncestor('FIGUREGROUP')
 
 export const FigureGroupForm = options => {
-  const { TYPE } = options
   const addFigureHandler = addFigure(options)
   const unwrapFiguresHandler = unwrapFigures(options)
   return createPropertyForm({
@@ -107,12 +102,7 @@ export const FigureGroupForm = options => {
       return null
     }
 
-    const figureGroup = value.blocks.reduce(
-      (memo, node) =>
-        memo || value.document.getFurthest(node.key, matchBlock(TYPE)),
-      undefined
-    )
-
+    const figureGroup = isFigureGroup(value)
     const handlerFactory = createOnFieldChange(
       change => {
         onChange(change)

--- a/components/editor/modules/infobox/index.js
+++ b/components/editor/modules/infobox/index.js
@@ -4,6 +4,7 @@ import MarkdownSerializer from 'slate-mdast-serializer'
 import { createPropertyForm, matchBlock } from '../../utils'
 import createUi from './ui'
 import InlineUI from '../../utils/InlineUI'
+import { matchAncestor } from '../../utils/matchers'
 
 export default ({ rule, subModules, TYPE }) => {
   const editorOptions = rule.editorOptions || {}
@@ -106,13 +107,7 @@ export default ({ rule, subModules, TYPE }) => {
               <InlineUI
                 node={node}
                 editor={editor}
-                isMatch={value =>
-                  value.blocks.some(
-                    block =>
-                      block.type === TYPE ||
-                      subModules?.some(m => m.TYPE === block.type)
-                  )
-                }
+                isMatch={matchAncestor(TYPE)}
               />
               {children}
             </Container>

--- a/components/editor/modules/infobox/index.js
+++ b/components/editor/modules/infobox/index.js
@@ -96,7 +96,6 @@ export default ({ rule, subModules, TYPE }) => {
 
           return (
             <Container
-              key='content'
               {...node.data.toJS()}
               editorPreview
               figureSize={

--- a/components/editor/modules/infobox/index.js
+++ b/components/editor/modules/infobox/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import MarkdownSerializer from 'slate-mdast-serializer'
 
-import { matchBlock } from '../../utils'
+import { createPropertyForm, matchBlock } from '../../utils'
 import createUi from './ui'
+import InlineUI from '../../utils/InlineUI'
 
 export default ({ rule, subModules, TYPE }) => {
   const editorOptions = rule.editorOptions || {}
@@ -86,13 +87,15 @@ export default ({ rule, subModules, TYPE }) => {
     }),
     plugins: [
       {
-        renderNode({ node, children, attributes }) {
+        renderNode({ node, children, attributes, editor }) {
           if (!serializerRule.match(node)) return
 
           const hasFigure =
             figureModule && node.nodes.find(n => n.type === figureModule.TYPE)
+
           return (
             <Container
+              key='content'
               {...node.data.toJS()}
               editorPreview
               figureSize={
@@ -100,6 +103,13 @@ export default ({ rule, subModules, TYPE }) => {
               }
               attributes={attributes}
             >
+              <InlineUI
+                key='ui'
+                node={node}
+                editor={editor}
+                TYPE={TYPE}
+                subModules={subModules}
+              />
               {children}
             </Container>
           )

--- a/components/editor/modules/infobox/index.js
+++ b/components/editor/modules/infobox/index.js
@@ -107,8 +107,13 @@ export default ({ rule, subModules, TYPE }) => {
                 key='ui'
                 node={node}
                 editor={editor}
-                TYPE={TYPE}
-                subModules={subModules}
+                isMatch={value =>
+                  value.blocks.some(
+                    block =>
+                      block.type === TYPE ||
+                      subModules?.some(m => m.TYPE === block.type)
+                  )
+                }
               />
               {children}
             </Container>

--- a/components/editor/modules/infobox/index.js
+++ b/components/editor/modules/infobox/index.js
@@ -104,7 +104,6 @@ export default ({ rule, subModules, TYPE }) => {
               attributes={attributes}
             >
               <InlineUI
-                key='ui'
                 node={node}
                 editor={editor}
                 isMatch={value =>

--- a/components/editor/modules/infobox/ui.js
+++ b/components/editor/modules/infobox/ui.js
@@ -8,6 +8,7 @@ import { createPropertyForm, buttonStyles, matchBlock } from '../../utils'
 import MetaForm from '../../utils/MetaForm'
 
 import injectBlock from '../../utils/injectBlock'
+import { matchSubmodules } from '../../utils/matchers'
 
 export default ({
   TYPE,
@@ -19,8 +20,7 @@ export default ({
 }) => {
   const { insertButtonText } = editorOptions
 
-  const isInfoboxBlock = block =>
-    block.type === TYPE || subModules.some(m => m.TYPE === block.type)
+  const isInfoboxBlock = matchSubmodules(TYPE, subModules)
   const Form = createPropertyForm({
     isDisabled: ({ value }) => !value.blocks.some(isInfoboxBlock)
   })(({ disabled, value, onChange }) => {

--- a/components/editor/modules/list/index.js
+++ b/components/editor/modules/list/index.js
@@ -10,6 +10,7 @@ import MarkdownSerializer from 'slate-mdast-serializer'
 import { Block } from 'slate'
 import InlineUI from '../../utils/InlineUI'
 import { matchAncestor } from '../../utils/matchers'
+import { parent } from '../../utils/selection'
 
 export default ({ rule, subModules, TYPE }) => {
   const {
@@ -117,13 +118,17 @@ export default ({ rule, subModules, TYPE }) => {
       {
         renderNode: ({ children, node, attributes, editor }) => {
           if (node.type !== TYPE) return
+          const isInInfobox =
+            parent(editor.state.value, node.key).type === 'INFOBOX'
           return (
             <div style={{ position: 'relative' }}>
-              <InlineUI
-                node={node}
-                editor={editor}
-                isMatch={matchAncestor(TYPE)}
-              />
+              {!isInInfobox && (
+                <InlineUI
+                  node={node}
+                  editor={editor}
+                  isMatch={matchAncestor(TYPE)}
+                />
+              )}
               <List attributes={attributes} data={node.data.toJS()}>
                 {children}
               </List>

--- a/components/editor/modules/list/index.js
+++ b/components/editor/modules/list/index.js
@@ -8,6 +8,8 @@ import {
 } from './ui'
 import MarkdownSerializer from 'slate-mdast-serializer'
 import { Block } from 'slate'
+import InlineUI from '../../utils/InlineUI'
+import { matchAncestor } from '../../utils/matchers'
 
 export default ({ rule, subModules, TYPE }) => {
   const {
@@ -113,12 +115,19 @@ export default ({ rule, subModules, TYPE }) => {
     },
     plugins: [
       {
-        renderNode: ({ children, node, attributes }) => {
+        renderNode: ({ children, node, attributes, editor }) => {
           if (node.type !== TYPE) return
           return (
-            <List attributes={attributes} data={node.data.toJS()}>
-              {children}
-            </List>
+            <div style={{ position: 'relative' }}>
+              <InlineUI
+                node={node}
+                editor={editor}
+                isMatch={matchAncestor(TYPE)}
+              />
+              <List attributes={attributes} data={node.data.toJS()}>
+                {children}
+              </List>
+            </div>
           )
         },
         onKeyDown(event, change) {

--- a/components/editor/modules/list/ui.js
+++ b/components/editor/modules/list/ui.js
@@ -9,6 +9,7 @@ import {
 import createOnFieldChange from '../../utils/createOnFieldChange'
 import injectBlock from '../../utils/injectBlock'
 import UIForm from '../../UIForm'
+import { matchAncestor } from '../../utils/matchers'
 
 export const ListForm = options => {
   const Form = ({ disabled, value, onChange, t }) => {
@@ -16,11 +17,7 @@ export const ListForm = options => {
       return null
     }
     // Multiple lists would involve more iteration work and given the fact, that this would happen on every select, I'd avoid it until necessary.
-    const list = value.blocks.reduce(
-      (memo, node) =>
-        memo || value.document.getFurthest(node.key, matchBlock(options.TYPE)),
-      undefined
-    )
+    const list = matchAncestor(options.TYPE)(value)
 
     const handlerFactory = createOnFieldChange(onChange, value, list)
 
@@ -41,13 +38,7 @@ export const ListForm = options => {
 
   return createPropertyForm({
     isDisabled: ({ value }) => {
-      const list = value.blocks.reduce(
-        (memo, node) =>
-          memo ||
-          value.document.getFurthest(node.key, matchBlock(options.TYPE)),
-        undefined
-      )
-
+      const list = matchAncestor(options.TYPE)(value)
       return !list
     }
   })(Form)

--- a/components/editor/modules/quote/index.js
+++ b/components/editor/modules/quote/index.js
@@ -3,6 +3,8 @@ import MarkdownSerializer from 'slate-mdast-serializer'
 
 import { matchBlock } from '../../utils'
 import createUi from './ui'
+import { matchAncestor } from '../../utils/matchers'
+import InlineUI from '../../utils/InlineUI'
 
 export default ({ rule, subModules, TYPE }) => {
   const editorOptions = rule.editorOptions || {}
@@ -81,7 +83,7 @@ export default ({ rule, subModules, TYPE }) => {
     }),
     plugins: [
       {
-        renderNode({ node, children, attributes }) {
+        renderNode({ node, children, attributes, editor }) {
           if (!serializerRule.match(node)) return
 
           const hasFigure =
@@ -92,6 +94,11 @@ export default ({ rule, subModules, TYPE }) => {
               hasFigure={hasFigure}
               attributes={attributes}
             >
+              <InlineUI
+                node={node}
+                editor={editor}
+                isMatch={matchAncestor(TYPE)}
+              />
               {children}
             </Container>
           )

--- a/components/editor/modules/quote/ui.js
+++ b/components/editor/modules/quote/ui.js
@@ -6,6 +6,7 @@ import { Radio, Label, A } from '@project-r/styleguide'
 import { createPropertyForm, buttonStyles } from '../../utils'
 
 import injectBlock from '../../utils/injectBlock'
+import { matchSubmodules } from '../../utils/matchers'
 
 export default ({
   TYPE,
@@ -17,8 +18,7 @@ export default ({
 }) => {
   const { insertButtonText } = editorOptions
 
-  const isBlock = block =>
-    block.type === TYPE || subModules.some(m => m.TYPE === block.type)
+  const isBlock = block => matchSubmodules(TYPE, subModules)
   const Form = createPropertyForm({
     isDisabled: ({ value }) => !value.blocks.some(isBlock)
   })(({ disabled, value, onChange }) => {

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -34,11 +34,8 @@ const MarkButton = props => {
   return <span {...buttonStyles.mark} {...props} />
 }
 
-const InlineUI = ({ editor, node, TYPE, subModules }) => {
-  const isInfoboxBlock = block =>
-    block.type === TYPE || subModules?.some(m => m.TYPE === block.type)
-  const isSelected =
-    editor.value.blocks.some(isInfoboxBlock) && !editor.value.isBlurred
+const InlineUI = ({ editor, node, isMatch }) => {
+  const isSelected = isMatch(editor.value) && !editor.value.isBlurred
   const isBreakout = parent(editor.state.value, node.key).nodes.size === 1
   if (!isSelected || isBreakout) return null
 

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { colors, P } from '@project-r/styleguide'
 import { css } from 'glamor'
 import buttonStyles from './buttonStyles'
 import { parent } from './selection'
@@ -15,27 +14,22 @@ const styles = {
   ui: css({
     position: 'absolute',
     zIndex: 10,
-    margin: 0,
-    padding: 0,
-    left: -87,
-    overflow: 'hidden'
-  }),
-  uiInlineRow: css({
-    backgroundColor: '#fff',
-    border: `1px solid ${colors.divider}`,
-    padding: '5px',
-    display: 'inline-block',
+    left: -75,
+    overflow: 'hidden',
+    display: 'flex',
     margin: 0
   })
 }
 
-const MarkButton = props => {
+export const MarkButton = props => {
   if (!props.onMouseDown) return null
   return <span {...buttonStyles.mark} {...props} />
 }
 
-const InlineUI = ({ editor, node, isMatch }) => {
-  const isSelected = isMatch(editor.value) && !editor.value.isBlurred
+const InlineUI = ({ editor, node, isMatch, children, style }) => {
+  const isSelected = isMatch
+    ? isMatch(editor.value) && !editor.value.isBlurred
+    : true
   const isBreakout = parent(editor.state.value, node.key).nodes.size === 1
   if (!isSelected || isBreakout) return null
 
@@ -54,15 +48,14 @@ const InlineUI = ({ editor, node, isMatch }) => {
 
   return (
     <div contentEditable={false} {...styles.uiContainer}>
-      <div contentEditable={false} {...styles.ui}>
-        <P {...styles.uiInlineRow}>
-          <MarkButton onMouseDown={moveHandler(-1)}>
-            <ArrowUpIcon size={24} />
-          </MarkButton>
-          <MarkButton onMouseDown={moveHandler(+1)}>
-            <ArrowDownIcon size={24} />
-          </MarkButton>
-        </P>
+      <div contentEditable={false} {...styles.ui} style={style}>
+        <MarkButton onMouseDown={moveHandler(-1)}>
+          <ArrowUpIcon size={24} />
+        </MarkButton>
+        <MarkButton onMouseDown={moveHandler(+1)}>
+          <ArrowDownIcon size={24} />
+        </MarkButton>
+        {children}
       </div>
     </div>
   )

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -39,17 +39,48 @@ const InlineUI = ({ editor, node, isMatch, children }) => {
 
   if (!isSelected) return null
 
+  const getNextParent = currentParent => {
+    const allCenters = parent(
+      editor.state.value,
+      currentParent.key
+    ).nodes.filter(n => n.type === 'CENTER')
+    const currentCenterIndex = allCenters.indexOf(currentParent)
+    if (allCenters.size === 1) {
+      return currentParent
+    } else if (currentCenterIndex === allCenters.nodes.size - 1) {
+      return allCenters[0]
+    } else {
+      return allCenters[currentCenterIndex + 1]
+    }
+  }
+
+  const getPreviousParent = currentParent => {
+    const allCenters = parent(
+      editor.state.value,
+      currentParent.key
+    ).nodes.filter(n => n.type === 'CENTER')
+    const currentCenterIndex = allCenters.indexOf(currentParent)
+    if (allCenters.size === 1) {
+      return currentParent
+    } else if (currentCenterIndex === 0) {
+      return allCenters[allCenters.size - 1]
+    } else {
+      return allCenters[currentCenterIndex - 1]
+    }
+  }
+
   const moveHandler = dir => event => {
-    const parentNode = parent(editor.state.value, node.key)
-    const nextIndex = parentNode.nodes.indexOf(node) + dir
-    const correctedIndex =
-      nextIndex === -1
-        ? parentNode.nodes.size - 1
-        : nextIndex % (parentNode.nodes.size - 1)
     event.preventDefault()
-    editor.change(t =>
-      t.moveNodeByKey(node.key, parentNode.key, correctedIndex)
-    )
+    let targetParent = parent(editor.state.value, node.key)
+    let targetIndex = targetParent.nodes.indexOf(node) + dir
+    if (targetIndex === -1) {
+      targetParent = getPreviousParent(targetParent)
+      targetIndex = targetParent.nodes.size - 1
+    } else if (targetIndex === targetParent.nodes.size) {
+      targetParent = getNextParent(targetParent)
+      targetIndex = 0
+    }
+    editor.change(t => t.moveNodeByKey(node.key, targetParent.key, targetIndex))
   }
 
   const isBreakout =

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -39,33 +39,36 @@ const InlineUI = ({ editor, node, isMatch, children }) => {
 
   if (!isSelected) return null
 
-  const getNextParent = currentParent => {
+  const getAllCenters = currentParent => {
     const allCenters = parent(
       editor.state.value,
       currentParent.key
     ).nodes.filter(n => n.type === 'CENTER')
-    const currentCenterIndex = allCenters.indexOf(currentParent)
+    return {
+      allCenters,
+      currentCenterIndex: allCenters.indexOf(currentParent)
+    }
+  }
+
+  const getNextParent = currentParent => {
+    const { allCenters, currentCenterIndex } = getAllCenters(currentParent)
     if (allCenters.size === 1) {
       return currentParent
-    } else if (currentCenterIndex === allCenters.nodes.size - 1) {
-      return allCenters[0]
+    } else if (currentCenterIndex === allCenters.size - 1) {
+      return allCenters.get(0)
     } else {
-      return allCenters[currentCenterIndex + 1]
+      return allCenters.get(currentCenterIndex + 1)
     }
   }
 
   const getPreviousParent = currentParent => {
-    const allCenters = parent(
-      editor.state.value,
-      currentParent.key
-    ).nodes.filter(n => n.type === 'CENTER')
-    const currentCenterIndex = allCenters.indexOf(currentParent)
+    const { allCenters, currentCenterIndex } = getAllCenters(currentParent)
     if (allCenters.size === 1) {
       return currentParent
     } else if (currentCenterIndex === 0) {
-      return allCenters[allCenters.size - 1]
+      return allCenters.get(allCenters.size - 1)
     } else {
-      return allCenters[currentCenterIndex - 1]
+      return allCenters.get(currentCenterIndex - 1)
     }
   }
 
@@ -75,8 +78,8 @@ const InlineUI = ({ editor, node, isMatch, children }) => {
     let targetIndex = targetParent.nodes.indexOf(node) + dir
     if (targetIndex === -1) {
       targetParent = getPreviousParent(targetParent)
-      targetIndex = targetParent.nodes.size - 1
-    } else if (targetIndex === targetParent.nodes.size) {
+      targetIndex = targetParent.nodes.size
+    } else if (targetIndex === targetParent.nodes.size - 1) {
       targetParent = getNextParent(targetParent)
       targetIndex = 0
     }

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -4,6 +4,7 @@ import buttonStyles from './buttonStyles'
 import { parent } from './selection'
 import ArrowUpIcon from 'react-icons/lib/md/arrow-upward'
 import ArrowDownIcon from 'react-icons/lib/md/arrow-downward'
+import scrollIntoView from 'scroll-into-view'
 
 const styles = {
   uiContainer: css({
@@ -74,6 +75,8 @@ const InlineUI = ({ editor, node, isMatch, children }) => {
 
   const moveHandler = dir => event => {
     event.preventDefault()
+    const rect = ref.current.getBoundingClientRect()
+    const top = (rect.top + rect.height / 2) / window.innerHeight
     let targetParent = parent(editor.state.value, node.key)
     let targetIndex = targetParent.nodes.indexOf(node) + dir
     if (targetIndex === -1) {
@@ -84,6 +87,14 @@ const InlineUI = ({ editor, node, isMatch, children }) => {
       targetIndex = 0
     }
     editor.change(t => t.moveNodeByKey(node.key, targetParent.key, targetIndex))
+    setTimeout(() => {
+      scrollIntoView(ref.current, {
+        time: 0,
+        align: {
+          top
+        }
+      })
+    }, 0)
   }
 
   const isBreakout =

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -39,8 +39,8 @@ const InlineUI = ({ editor, node, TYPE, subModules }) => {
     block.type === TYPE || subModules?.some(m => m.TYPE === block.type)
   const isSelected =
     editor.value.blocks.some(isInfoboxBlock) && !editor.value.isBlurred
-
-  if (!isSelected) return null
+  const isBreakout = parent(editor.state.value, node.key).nodes.size === 1
+  if (!isSelected || isBreakout) return null
 
   const moveHandler = dir => event => {
     const parentNode = parent(editor.state.value, node.key)

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { css, merge } from 'glamor'
 import buttonStyles from './buttonStyles'
 import { parent } from './selection'
@@ -30,12 +30,13 @@ export const MarkButton = props => {
 
 const InlineUI = ({ editor, node, isMatch, children }) => {
   const ref = useRef()
-  const isSelected = isMatch
-    ? isMatch(editor.value) && !editor.value.isBlurred
-    : true
-  const isBreakout =
-    !parent(editor.state.value, node.key).type ||
-    parent(editor.state.value, node.key).nodes.size === 1
+  const [width, setWidth] = useState(0)
+  const isSelected = isMatch(editor.value) && !editor.value.isBlurred
+
+  useEffect(() => {
+    setWidth(ref.current?.getBoundingClientRect().width)
+  }, [ref, isSelected])
+
   if (!isSelected) return null
 
   const moveHandler = dir => event => {
@@ -50,7 +51,10 @@ const InlineUI = ({ editor, node, isMatch, children }) => {
       t.moveNodeByKey(node.key, parentNode.key, correctedIndex)
     )
   }
-  const currentWidth = ref.current?.getBoundingClientRect().width
+
+  const isBreakout =
+    !parent(editor.state.value, node.key).type ||
+    parent(editor.state.value, node.key).nodes.size === 1
 
   return (
     <div contentEditable={false} {...styles.uiContainer}>
@@ -59,8 +63,7 @@ const InlineUI = ({ editor, node, isMatch, children }) => {
         ref={ref}
         {...merge(styles.ui, isBreakout && styles.breakoutUI)}
         style={{
-          left: isBreakout ? 0 : -(currentWidth + 15),
-          opacity: currentWidth ? 1 : 0
+          left: isBreakout ? 0 : -(width + 15)
         }}
       >
         {!isBreakout && (

--- a/components/editor/utils/InlineUI.js
+++ b/components/editor/utils/InlineUI.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import { colors, P } from '@project-r/styleguide'
+import { css } from 'glamor'
+import buttonStyles from './buttonStyles'
+import { parent } from './selection'
+import ArrowUpIcon from 'react-icons/lib/md/arrow-upward'
+import ArrowDownIcon from 'react-icons/lib/md/arrow-downward'
+
+const styles = {
+  uiContainer: css({
+    position: 'relative',
+    height: 0,
+    overflow: 'visible'
+  }),
+  ui: css({
+    position: 'absolute',
+    zIndex: 10,
+    margin: 0,
+    padding: 0,
+    left: -87,
+    overflow: 'hidden'
+  }),
+  uiInlineRow: css({
+    backgroundColor: '#fff',
+    border: `1px solid ${colors.divider}`,
+    padding: '5px',
+    display: 'inline-block',
+    margin: 0
+  })
+}
+
+const MarkButton = props => {
+  if (!props.onMouseDown) return null
+  return <span {...buttonStyles.mark} {...props} />
+}
+
+const InlineUI = ({ editor, node, TYPE, subModules }) => {
+  const isInfoboxBlock = block =>
+    block.type === TYPE || subModules?.some(m => m.TYPE === block.type)
+  const isSelected =
+    editor.value.blocks.some(isInfoboxBlock) && !editor.value.isBlurred
+
+  if (!isSelected) return null
+
+  const moveHandler = dir => event => {
+    const parentNode = parent(editor.state.value, node.key)
+    const nextIndex = parentNode.nodes.indexOf(node) + dir
+    const correctedIndex =
+      nextIndex === -1
+        ? parentNode.nodes.size - 1
+        : nextIndex % (parentNode.nodes.size - 1)
+    event.preventDefault()
+    editor.change(t =>
+      t.moveNodeByKey(node.key, parentNode.key, correctedIndex)
+    )
+  }
+
+  return (
+    <div contentEditable={false} {...styles.uiContainer}>
+      <div contentEditable={false} {...styles.ui}>
+        <P {...styles.uiInlineRow}>
+          <MarkButton onMouseDown={moveHandler(-1)}>
+            <ArrowUpIcon size={24} />
+          </MarkButton>
+          <MarkButton onMouseDown={moveHandler(+1)}>
+            <ArrowDownIcon size={24} />
+          </MarkButton>
+        </P>
+      </div>
+    </div>
+  )
+}
+
+export default InlineUI

--- a/components/editor/utils/OverlayFormContext.js
+++ b/components/editor/utils/OverlayFormContext.js
@@ -1,0 +1,17 @@
+import React, { useState } from 'react'
+
+export const OverlayFormContext = React.createContext()
+
+export const OverlayFormContextProvider = ({ children }) => {
+  const [showModal, setShowModal] = useState(false)
+  return (
+    <OverlayFormContext.Provider
+      value={{
+        showModal,
+        setShowModal
+      }}
+    >
+      {children}
+    </OverlayFormContext.Provider>
+  )
+}

--- a/components/editor/utils/OverlayFormManager.js
+++ b/components/editor/utils/OverlayFormManager.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, useContext, useState } from 'react'
 import PropTypes from 'prop-types'
 import SlatePropTypes from 'slate-prop-types'
 import { css } from 'glamor'
@@ -9,6 +9,8 @@ import MdEdit from 'react-icons/lib/md/edit'
 import OverlayForm from './OverlayForm'
 import InlineUI, { MarkButton } from './InlineUI'
 import ArrowDownIcon from 'react-icons/lib/md/arrow-downward'
+import { matchAncestor } from './matchers'
+import { OverlayFormContext } from './OverlayFormContext'
 
 const styles = {
   editButton: css({
@@ -39,71 +41,50 @@ const EditButton = ({ onClick, size, parentType }) => {
   )
 }
 
-class OverlayFormManager extends Component {
-  constructor(...args) {
-    super(...args)
-    this.state = {
-      showModal: false
-    }
-  }
-  render() {
-    const {
-      editor,
-      node,
-      attributes,
-      onChange,
-      component,
-      preview,
-      autoDarkModePreview,
-      extra,
-      showPreview,
-      title,
-      nested,
-      children
-    } = this.props
-    const startEditing = () => {
-      this.setState({ showModal: true })
-    }
-    const showModal = this.state.showModal || node.data.get('isNew')
-    const parent = editor.value.document.getParent(node.key)
+const OverlayFormManager = ({
+  editor,
+  node,
+  attributes,
+  onChange,
+  component,
+  preview,
+  autoDarkModePreview,
+  extra,
+  showPreview,
+  title,
+  nested,
+  children
+}) => {
+  const { showModal, setShowModal } = useContext(OverlayFormContext)
+  const startEditing = () => setShowModal(true)
+  const isOpen = showModal || node.data.get('isNew')
+  const parent = editor.value.document.getParent(node.key)
 
-    console.log(node.type, parent.type)
-
-    return (
-      <div {...attributes} style={{ position: 'relative' }}>
-        <InlineUI
-          node={nested ? parent : node}
-          editor={editor}
-          style={{ left: -100 }}
-        >
-          <MarkButton onMouseDown={startEditing}>
-            <MdEdit size={20} />
-          </MarkButton>
-        </InlineUI>
-        {showModal && (
-          <OverlayForm
-            preview={preview}
-            autoDarkModePreview={autoDarkModePreview}
-            showPreview={showPreview}
-            title={title}
-            extra={extra}
-            onClose={() => {
-              this.setState({ showModal: false })
-              node.data.get('isNew') &&
-                editor.change(change => {
-                  change.setNodeByKey(node.key, {
-                    data: node.data.delete('isNew')
-                  })
+  return (
+    <div {...attributes} style={{ position: 'relative' }}>
+      {isOpen && (
+        <OverlayForm
+          preview={preview}
+          autoDarkModePreview={autoDarkModePreview}
+          showPreview={showPreview}
+          title={title}
+          extra={extra}
+          onClose={() => {
+            setShowModal(false)
+            node.data.get('isNew') &&
+              editor.change(change => {
+                change.setNodeByKey(node.key, {
+                  data: node.data.delete('isNew')
                 })
-            }}
-          >
-            {children({ data: node.data, onChange })}
-          </OverlayForm>
-        )}
-        <div onDoubleClick={startEditing}>{component || preview}</div>
-      </div>
-    )
-  }
+              })
+          }}
+        >
+          {children({ data: node.data, onChange })}
+        </OverlayForm>
+      )}
+      <div onDoubleClick={startEditing}>{component || preview}</div>
+    </div>
+  )
 }
 
 OverlayFormManager.propTypes = {

--- a/components/editor/utils/OverlayFormManager.js
+++ b/components/editor/utils/OverlayFormManager.js
@@ -1,45 +1,8 @@
-import React, { Component, useContext, useState } from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import SlatePropTypes from 'slate-prop-types'
-import { css } from 'glamor'
-import { IconButton, useColorContext } from '@project-r/styleguide'
-
-import MdEdit from 'react-icons/lib/md/edit'
-
 import OverlayForm from './OverlayForm'
-import InlineUI, { MarkButton } from './InlineUI'
-import ArrowDownIcon from 'react-icons/lib/md/arrow-downward'
-import { matchAncestor } from './matchers'
 import { OverlayFormContext } from './OverlayFormContext'
-
-const styles = {
-  editButton: css({
-    position: 'absolute',
-    zIndex: 1,
-    fontSize: 24,
-    ':hover': {
-      cursor: 'pointer'
-    }
-  })
-}
-
-const EditButton = ({ onClick, size, parentType }) => {
-  const [colorScheme] = useColorContext()
-
-  return (
-    <div
-      //{...styles.editButton}
-      role='button'
-      onClick={onClick}
-      /*style={{
-        top: size === 'breakout' || !parentType ? -40 : 0,
-        left: !parentType ? 0 : -40
-      }}*/
-    >
-      <MdEdit {...colorScheme.set('fill', 'text')} />
-    </div>
-  )
-}
 
 const OverlayFormManager = ({
   editor,
@@ -52,13 +15,11 @@ const OverlayFormManager = ({
   extra,
   showPreview,
   title,
-  nested,
   children
 }) => {
   const { showModal, setShowModal } = useContext(OverlayFormContext)
   const startEditing = () => setShowModal(true)
   const isOpen = showModal || node.data.get('isNew')
-  const parent = editor.value.document.getParent(node.key)
 
   return (
     <div {...attributes} style={{ position: 'relative' }}>

--- a/components/editor/utils/OverlayFormManager.js
+++ b/components/editor/utils/OverlayFormManager.js
@@ -2,11 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import SlatePropTypes from 'slate-prop-types'
 import { css } from 'glamor'
-import { useColorContext } from '@project-r/styleguide'
+import { IconButton, useColorContext } from '@project-r/styleguide'
 
 import MdEdit from 'react-icons/lib/md/edit'
 
 import OverlayForm from './OverlayForm'
+import InlineUI, { MarkButton } from './InlineUI'
+import ArrowDownIcon from 'react-icons/lib/md/arrow-downward'
 
 const styles = {
   editButton: css({
@@ -24,13 +26,13 @@ const EditButton = ({ onClick, size, parentType }) => {
 
   return (
     <div
-      {...styles.editButton}
+      //{...styles.editButton}
       role='button'
       onClick={onClick}
-      style={{
+      /*style={{
         top: size === 'breakout' || !parentType ? -40 : 0,
         left: !parentType ? 0 : -40
-      }}
+      }}*/
     >
       <MdEdit {...colorScheme.set('fill', 'text')} />
     </div>
@@ -56,6 +58,7 @@ class OverlayFormManager extends Component {
       extra,
       showPreview,
       title,
+      nested,
       children
     } = this.props
     const startEditing = () => {
@@ -65,16 +68,16 @@ class OverlayFormManager extends Component {
     const parent = editor.value.document.getParent(node.key)
 
     return (
-      <div
-        {...attributes}
-        style={{ position: 'relative' }}
-        onDoubleClick={startEditing}
-      >
-        <EditButton
-          size={node.data.get('size')}
-          parentType={parent.type}
-          onClick={startEditing}
-        />
+      <div {...attributes} style={{ position: 'relative' }}>
+        <InlineUI
+          node={nested ? parent : node}
+          editor={editor}
+          style={{ left: -86 }}
+        >
+          <MarkButton onMouseDown={startEditing}>
+            <MdEdit size={20} />
+          </MarkButton>
+        </InlineUI>
         {showModal && (
           <OverlayForm
             preview={preview}
@@ -95,7 +98,7 @@ class OverlayFormManager extends Component {
             {children({ data: node.data, onChange })}
           </OverlayForm>
         )}
-        {component || preview}
+        <div onDoubleClick={startEditing}>{component || preview}</div>
       </div>
     )
   }

--- a/components/editor/utils/OverlayFormManager.js
+++ b/components/editor/utils/OverlayFormManager.js
@@ -67,12 +67,14 @@ class OverlayFormManager extends Component {
     const showModal = this.state.showModal || node.data.get('isNew')
     const parent = editor.value.document.getParent(node.key)
 
+    console.log(node.type, parent.type)
+
     return (
       <div {...attributes} style={{ position: 'relative' }}>
         <InlineUI
           node={nested ? parent : node}
           editor={editor}
-          style={{ left: -86 }}
+          style={{ left: -100 }}
         >
           <MarkButton onMouseDown={startEditing}>
             <MdEdit size={20} />

--- a/components/editor/utils/matchers.js
+++ b/components/editor/utils/matchers.js
@@ -6,3 +6,6 @@ export const matchAncestor = TYPE => value =>
       memo || value.document.getFurthest(node.key, matchBlock(TYPE)),
     undefined
   )
+
+export const matchSubmodules = (TYPE, subModules) => block =>
+  block.type === TYPE || subModules.some(m => m.TYPE === block.type)

--- a/components/editor/utils/matchers.js
+++ b/components/editor/utils/matchers.js
@@ -1,0 +1,8 @@
+import { matchBlock } from './index'
+
+export const matchAncestor = TYPE => value =>
+  value.blocks.reduce(
+    (memo, node) =>
+      memo || value.document.getFurthest(node.key, matchBlock(TYPE)),
+    undefined
+  )


### PR DESCRIPTION
### Up/down inline UI

<img width="1569" alt="Screenshot 2021-11-30 at 09 52 02" src="https://user-images.githubusercontent.com/3907984/144016430-55477a52-1bb4-4551-8855-c0125e997d06.png">

Supported elements: 

- [x]  infobox
- [x]  picture
- [x]  picture group
- [x]  list/enum
- [x]  chart
- [x]  dynamic component
- [x]  typgraphic quote
- [x]  long quote
- [x]  embed

Arrows appears on focus. Jumps through breakout elements.

### DC/Charts edition

<img width="1569" alt="Screenshot 2021-11-30 at 09 51 47" src="https://user-images.githubusercontent.com/3907984/144017416-0a9c00d9-9142-4b9e-8467-4a826921cb17.png">

For dynamic components and charts, the arrows and the edit UI were merged into a single UI, with the help of a new context.

