### PR TITLE
fix(CopyPaste): add support to teaser group

### DIFF
--- a/components/editor/modules/teasergroup/index.js
+++ b/components/editor/modules/teasergroup/index.js
@@ -96,7 +96,14 @@ const teaserGroupPlugin = options => {
       const isSelected = teaser === node && !editor.value.isBlurred
 
       return [
-        isSelected && <TeaserInlineUI key='ui' node={node} editor={editor} />,
+        isSelected && (
+          <TeaserInlineUI
+            key='ui'
+            node={node}
+            editor={editor}
+            serializer={getSerializer(options)}
+          />
+        ),
         <TeaserGroup key='teaser' {...node.data.toJS()} attributes={attributes}>
           {children}
         </TeaserGroup>


### PR DESCRIPTION
The required serializer wasn't passed down to the copy-paste component for teaser groups (as opposed to simple teasers), so yeah…
This PR fixes that.