### PR TITLE
Try The JSON Again

### DIFF
--- a/components/editor/modules/dynamiccomponent/EditOverlay.js
+++ b/components/editor/modules/dynamiccomponent/EditOverlay.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import { fromJS } from 'immutable'
-import debounce from 'lodash.debounce'
+import debounce from 'lodash/debounce'
 
 import OverlayFormManager from '../../utils/OverlayFormManager'
 import { JSONEditor, PlainEditor } from '../../utils/CodeEditorFields'

--- a/components/editor/modules/link/ui.js
+++ b/components/editor/modules/link/ui.js
@@ -14,7 +14,7 @@ import RepoSearch from '../../utils/RepoSearch'
 import { AutoSlugLinkInfo } from '../../utils/github'
 import withT from '../../../../lib/withT'
 import gql from 'graphql-tag'
-import debounce from 'lodash.debounce'
+import debounce from 'lodash/debounce'
 
 import { createInlineButton, matchInline, buttonStyles } from '../../utils'
 

--- a/components/editor/utils/CodeEditorFields.js
+++ b/components/editor/utils/CodeEditorFields.js
@@ -156,18 +156,18 @@ export const JSONEditor = ({
   const onChangeRef = useRef()
   onChangeRef.current = onChange
 
-  // save config onChange and onBlur
+  // slowly save valid json on change (immediately flushed on blur)
   const slowSave = useCallback(
     debounce(() => {
       setIsValid(!!validJsonRef.current)
       if (validJsonRef.current && onChangeRef.current) {
         onChangeRef.current(validJsonRef.current)
       }
-    }, 300),
+    }, 500),
     []
   )
 
-  // editor text with well formatted config from saved state
+  // set editor text with well formatted config from saved state when not isEditing
   useEffect(() => {
     if (!isEditing) {
       setStateValue(stringify(config))

--- a/components/editor/utils/CodeEditorFields.js
+++ b/components/editor/utils/CodeEditorFields.js
@@ -1,8 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Controlled as CodeMirror } from 'react-codemirror2'
-import { colors, fontFamilies, Label, useDebounce } from '@project-r/styleguide'
+import {
+  fontStyles,
+  Label,
+  useColorContext,
+  useDebounce
+} from '@project-r/styleguide'
 
 // CodeMirror can only run in the browser
 if (process.browser && window) {
@@ -17,28 +22,9 @@ if (process.browser && window) {
 
 const LINE_HEIGHT = 20.4
 
-const styles = {
-  codemirror: css({
-    marginBottom: 20,
-    padding: 0,
-    '& .CodeMirror': {
-      height: 'auto',
-      fontFamily: fontFamilies.monospaceRegular,
-      fontSize: 14,
-      color: colors.text
-    },
-    '& .CodeMirror-lines': {
-      backgroundColor: colors.light.hover
-    },
-    '& .CodeMirror-cursor': {
-      width: 1,
-      background: colors.light.text
-    }
-  })
-}
-
 const CodeMirrorField = ({
   label,
+  error,
   value,
   onChange,
   onPaste,
@@ -47,12 +33,42 @@ const CodeMirrorField = ({
   onBlur,
   linesShown
 }) => {
-  const showLabel = label || linesShown
+  const [colorScheme] = useColorContext()
+  const showLabel = label || linesShown || error
+
+  const codemirrorRule = useMemo(
+    () =>
+      css({
+        marginBottom: 20,
+        padding: 0,
+        '& .CodeMirror': {
+          height: 'auto',
+          ...fontStyles.monospaceRegular,
+          fontSize: 14,
+          color: colorScheme.getCSSColor('text')
+        },
+        '& .CodeMirror-lines': {
+          backgroundColor: colorScheme.getCSSColor('hover')
+        },
+        '& .CodeMirror-cursor': {
+          width: 1,
+          background: colorScheme.getCSSColor('text')
+        }
+      }),
+    [colorScheme]
+  )
+
   return (
-    <div {...styles.codemirror}>
+    <div {...codemirrorRule}>
       {showLabel && (
         <div style={{ marginBottom: 10 }}>
-          <Label>{label && <span>{label}</span>}</Label>
+          <Label>
+            {error ? (
+              <span {...colorScheme.set('color', 'error')}>{error}</span>
+            ) : (
+              label
+            )}
+          </Label>
         </div>
       )}
       <div
@@ -75,16 +91,16 @@ const CodeMirrorField = ({
             lineWrapping: true,
             ...options
           }}
-          onBeforeChange={(editor, data, value) => {
+          onBeforeChange={(_, __, value) => {
             onChange(value)
           }}
-          onPaste={(editor, event) => {
+          onPaste={(_, event) => {
             onPaste && onPaste(event)
           }}
-          onBlur={(editor, event) => {
+          onBlur={(_, event) => {
             onBlur && onBlur(event)
           }}
-          onFocus={(editor, event) => {
+          onFocus={(_, event) => {
             onFocus && onFocus(event)
           }}
         />
@@ -118,6 +134,13 @@ export const PlainEditor = ({
 }
 
 const stringify = json => (json ? JSON.stringify(json, null, 2) : '')
+const safeParse = string => {
+  let json
+  try {
+    json = JSON.parse(string)
+  } catch (e) {}
+  return json
+}
 
 export const JSONEditor = ({
   label,
@@ -126,30 +149,49 @@ export const JSONEditor = ({
   linesShown,
   readOnly
 }) => {
-  const [stateValue, setStateValue] = useState('')
+  const [isEditing, setEditing] = useState()
+  const [stateValue, setStateValue] = useState(stringify(config))
   const [debouncedStateValue] = useDebounce(stateValue, 300)
-  const configRef = useRef()
-  configRef.current = config
-  const valueRef = useRef()
-  valueRef.current = stateValue
+
+  // we need to use a ref for invalid because
+  // onBlur and onFocus callbacks are not refreshed
+  // as of react-codemirror2 7.2.1
+  const validJsonRef = useRef(true)
 
   useEffect(() => {
-    let json
-    try {
-      json = JSON.parse(debouncedStateValue)
-    } catch (e) {}
+    const json = safeParse(debouncedStateValue)
+    validJsonRef.current = !!json
     if (json) {
       onChange && onChange(json)
     }
   }, [debouncedStateValue])
+  useEffect(() => {
+    // always try to safe before unmount
+    return () => {
+      const json = safeParse(stateValue)
+      if (json) {
+        onChange && onChange(json)
+      }
+    }
+  }, [stateValue])
+  useEffect(() => {
+    if (!isEditing) {
+      setStateValue(stringify(config))
+    }
+  }, [isEditing, config])
 
   return (
     <CodeMirrorField
-      onFocus={() => setStateValue(stringify(configRef.current))}
+      onFocus={() => {
+        setEditing(true)
+      }}
       onBlur={() => {
-        setStateValue(stringify(JSON.parse(valueRef.current)))
+        if (validJsonRef.current) {
+          setEditing(false)
+        }
       }}
       label={label}
+      error={!validJsonRef.current && `${label} ungültig, JSON invalid`}
       value={stateValue}
       linesShown={linesShown}
       options={{
@@ -162,6 +204,7 @@ export const JSONEditor = ({
       }}
       onChange={newValue => {
         setStateValue(newValue)
+        validJsonRef.current = !!safeParse(newValue)
       }}
     />
   )

--- a/components/editor/utils/CodeEditorFields.js
+++ b/components/editor/utils/CodeEditorFields.js
@@ -3,7 +3,7 @@ import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Controlled as CodeMirror } from 'react-codemirror2'
 import { fontStyles, Label, useColorContext } from '@project-r/styleguide'
-import debounce from 'lodash.debounce'
+import debounce from 'lodash/debounce'
 
 // CodeMirror can only run in the browser
 if (process.browser && window) {

--- a/components/editor/utils/OverlayFormManager.js
+++ b/components/editor/utils/OverlayFormManager.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import SlatePropTypes from 'slate-prop-types'
 import OverlayForm from './OverlayForm'
@@ -17,12 +17,21 @@ const OverlayFormManager = ({
   children
 }) => {
   const { showModal, setShowModal } = useContext(OverlayFormContext)
-  const startEditing = () => setShowModal(true)
-  const isOpen = showModal || node.data.get('isNew')
+  const isNew = node.data.get('isNew')
+  useEffect(() => {
+    if (isNew) {
+      setShowModal(true)
+      editor.change(change => {
+        change.setNodeByKey(node.key, {
+          data: node.data.delete('isNew')
+        })
+      })
+    }
+  }, [isNew])
 
   return (
     <div {...attributes} style={{ position: 'relative' }}>
-      {isOpen && (
+      {showModal && (
         <OverlayForm
           preview={preview}
           showPreview={showPreview}
@@ -30,18 +39,12 @@ const OverlayFormManager = ({
           extra={extra}
           onClose={() => {
             setShowModal(false)
-            node.data.get('isNew') &&
-              editor.change(change => {
-                change.setNodeByKey(node.key, {
-                  data: node.data.delete('isNew')
-                })
-              })
           }}
         >
           {children({ data: node.data, onChange })}
         </OverlayForm>
       )}
-      <div onDoubleClick={startEditing}>{component || preview}</div>
+      <div onDoubleClick={() => setShowModal(true)}>{component || preview}</div>
     </div>
   )
 }

--- a/components/editor/utils/RepoSearch.js
+++ b/components/editor/utils/RepoSearch.js
@@ -7,7 +7,7 @@ import {
   Label,
   Interaction
 } from '@project-r/styleguide'
-import debounce from 'lodash.debounce'
+import debounce from 'lodash/debounce'
 
 import { GITHUB_ORG, REPO_PREFIX } from '../../../lib/settings'
 import { swissTime } from '../../../lib/utils/format'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9434,14 +9434,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.escape": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "isomorphic-unfetch": "^3.0.0",
     "js-yaml": "^3.14.0",
     "jsonlint-mod": "^1.7.6",
-    "lodash.debounce": "^4.0.8",
+    "lodash": "^4.17.21",
     "mdast-react-render": "^1.2.0",
     "next": "^9.5.4",
     "next-routes": "^1.4.2",

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -3,7 +3,7 @@ import { withRouter } from 'next/router'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
 import { Value, resetKeyGenerator } from 'slate'
-import debounce from 'lodash.debounce'
+import debounce from 'lodash/debounce'
 import { timeFormat } from 'd3-time-format'
 import { parse } from '@orbiting/remark-preset'
 


### PR DESCRIPTION
Changes:
- switch to main `lodash` package instead of `lodash.debounce` to be in synch with styleguide and frontend
- refactor `isNew` usage on charts which automatically opens the edit overlay
- reintroduce improve json editor with error display

The issue with pasting were race conditions caused by incorrect `useEffect` usage. I've now reduced the `useEffect` usage to a absolute minimum and no longer save during a `useEffect` which should also eliminate any race conditions we had with the old json editor which is currently live.