### PR TITLE
fix(editor): Drop memo format button if template

### DIFF
--- a/components/editor/modules/memo/index.js
+++ b/components/editor/modules/memo/index.js
@@ -172,17 +172,23 @@ const MemoModule = ({ rule, TYPE, context }) => {
       textFormatButtons: [
         createInlineButton({
           type: TYPE
-        })(({ active, disabled, visible, ...props }) => (
-          <span
-            {...buttonStyles.mark}
-            {...props}
-            data-active={active}
-            data-disabled={disabled || context.isTemplate}
-            data-visible={visible}
-          >
-            <MemoIcon />
-          </span>
-        ))
+        })(({ active, disabled, visible, ...props }) => {
+          if (context.isTemplate) {
+            return false
+          }
+
+          return (
+            <span
+              {...buttonStyles.mark}
+              {...props}
+              data-active={active}
+              data-disabled={disabled}
+              data-visible={visible}
+            >
+              <MemoIcon />
+            </span>
+          )
+        })
       ]
     },
     plugins: [

--- a/components/editor/modules/memo/index.js
+++ b/components/editor/modules/memo/index.js
@@ -174,7 +174,7 @@ const MemoModule = ({ rule, TYPE, context }) => {
           type: TYPE
         })(({ active, disabled, visible, ...props }) => {
           if (context.isTemplate) {
-            return false
+            return null
           }
 
           return (


### PR DESCRIPTION
If document is a template, do not render memo format button.

While button was disabled for templates, it remained clickable.